### PR TITLE
Switch from mingetty to agetty

### DIFF
--- a/fs/filesystem-tweaks/usr/lib/systemd/system/getty@.service
+++ b/fs/filesystem-tweaks/usr/lib/systemd/system/getty@.service
@@ -38,7 +38,7 @@ ConditionPathExists=/dev/tty0
 # the entered username.
 # The hardcoded tty0 on ExecStart is a netkit fix
 ExecStart=
-ExecStart=-/sbin/mingetty --noclear --noissue --autologin root tty0
+ExecStart=-/sbin/agetty --noclear --noissue --autologin root tty0
 Type=idle
 Restart=always
 RestartSec=0

--- a/fs/packages-list
+++ b/fs/packages-list
@@ -19,6 +19,7 @@ dnsmasq
 dnsutils
 ebtables
 uml-utilities
+util-linux
 # emacs23-nox
 file
 freeradius
@@ -39,7 +40,6 @@ lxctl
 lynx
 mdns-scan
 mime-support
-mingetty
 minicom
 mrd6
 mtr-tiny


### PR DESCRIPTION
Changing from mingetty to agetty:
- added `util-linux` to package list (this contains agetty)
- removed `mingetty` from package list as it's no longer needed
- changed command in getty systemd service file to start agetty instead of mingetty