### PR TITLE
Improving Dockerfile and adding docker script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,5 @@
-*
+# Ignore by default
+**
+
+# Allow docker-start.sh
+!docker-start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,5 @@ WORKDIR /netkit-build
 # Make loop mounting work
 RUN mknod /dev/loop0 b 7 0
 
-CMD /bin/bash -c "mount -t proc proc /proc && make ${MAKE_ARGS}"
+COPY docker-start.sh /docker-start.sh
+CMD /bin/bash -c "/docker-start.sh"

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+MAG='\033[0;35m'
+LMAG='\033[0;95m'
+WH='\033[0;97m'
+CY='\033[0;36m'
+LG='\033[0;92m'
+RST='\033[0m'
+
+[[ -n $(mount -l -t proc) ]] && \
+    echo -e "\n/proc already mounted ${GREEN}[✓]"${RST} || \
+    mount -t proc proc /proc
+
+[[ -n $(mount -l -t proc) ]] || {
+    echo -e "\n${RED}Could not mount /proc. Exitting.${RST}" \
+    && exit 1
+}
+
+mount | grep '/netkit-build' &> /dev/null && \
+    echo -e "\n/netkit-build mounted ${GREEN}[✓]${RST}" || {
+    echo -e "\n${RED}Source Code Dir not mounted. ${RST}
+Remember to pass a volume in the docker argument with \`-v PATH_TO_NETKIT_JH_BUILD:/netkit-build\`
+
+${MAG}https://netkit-jh.github.io/docs/dev/guides/dockerbuild/${RST}
+
+Exitting.\n" \
+    && exit 1
+}
+
+# Should already be in /netkit-build from WORKDIR in Dockerfile
+if [ -f "Makefile" ]; then
+    echo -e "\nAttempting to run make with args ${MAKE_ARGS}\n"
+    make ${MAKE_ARGS} && \
+        echo -e "\nMake exitted successfully.${GREEN}[✓]${RST}\n" ||
+        echo -e "\n${RED}Error running make.${RST}\n"
+else
+    echo -e "\n${RED}Makefile doesn't exist.${RST}
+
+Have you cloned the netkit-jh-build source? Please check you are passing the correct directory as a docker volume. You may need to give a full path.
+
+${MAG}https://netkit-jh.github.io/docs/dev/guides/dockerbuild/${RST}
+
+Exitting.\n"
+    exit 1
+fi


### PR DESCRIPTION
Originally docker ran a mount command to mount /proc, followed by make. In docker for windows this failed as /proc was already mounted in the container. 

The image now includes a docker-start.sh script which will only attempt to mount /proc if it doesn't already exist. It also checks that you have mounted a directory at /netkit-build and that there is a makefile in that directory. If these fail there are more verbose errors that should help people :)