### PR TITLE
Replace $PWD usage in check_configuration scripts

### DIFF
--- a/core/setup_scripts/check_configuration.d/01-check_path.sh
+++ b/core/setup_scripts/check_configuration.d/01-check_path.sh
@@ -32,12 +32,12 @@
 
 check_message "Checking path correctness... "
 
-if echo "${PWD}" | grep -q " "; then
+if echo "$CHECK_NETKIT_HOME" | grep -q " "; then
    echo "failed!"
    echo
    echo "*** Error: Netkit appears to be installed inside a directory whose path"
    echo "contains spaces:"
-   echo "\"$PWD\""
+   echo "\"$CHECK_NETKIT_HOME\""
    echo "Please move it to a different directory and try again."
    echo
    check_failure

--- a/core/setup_scripts/check_configuration.d/02-check_environment.sh
+++ b/core/setup_scripts/check_configuration.d/02-check_environment.sh
@@ -38,30 +38,30 @@ if [ -z "$NETKIT_HOME" ]; then
    echo "*** Error: the environment variable NETKIT_HOME is not set. You should"
    echo "set it to the following value:"
    echo
-   echo $PWD
+   echo $CHECK_NETKIT_HOME
    echo
    echo "You can use one of the following commands, depending on the shell you"
    echo "are using:"
    echo
-   echo "(for bash) export NETKIT_HOME=$PWD"
-   echo "(for csh)  setenv NETKIT_HOME $PWD"
+   echo "(for bash) export NETKIT_HOME=$CHECK_NETKIT_HOME"
+   echo "(for csh)  setenv NETKIT_HOME $CHECK_NETKIT_HOME"
    echo
    check_failure
 else
-   if [ "$NETKIT_HOME" != "$(dirname $PWD)" -a "$NETKIT_HOME" != "$(dirname $PWD)/" ]; then
+   if [ "$NETKIT_HOME" != "$CHECK_NETKIT_HOME" -a "$NETKIT_HOME" != "$CHECK_NETKIT_HOME/" ]; then
       echo "failed!"
       echo
       echo "*** Error: the environment variable NETKIT_HOME currently points at the"
       echo "wrong directory:"
       echo
       echo "(current value) $NETKIT_HOME"
-      echo "(should be)     $PWD"
+      echo "(should be)     $CHECK_NETKIT_HOME"
       echo
       echo "In order to fix this, you can use one of the following commands, depending"
       echo "on the shell you are using:"
       echo
-      echo "(for bash) export NETKIT_HOME=$PWD"
-      echo "(for csh)  setenv NETKIT_HOME $PWD"
+      echo "(for bash) export NETKIT_HOME=$CHECK_NETKIT_HOME"
+      echo "(for csh)  setenv NETKIT_HOME $CHECK_NETKIT_HOME"
       echo
       check_failure
    else

--- a/core/setup_scripts/check_configuration.sh
+++ b/core/setup_scripts/check_configuration.sh
@@ -26,6 +26,9 @@
 FIXMODE=0
 ISSUE_WARNING=0
 
+# Get the assumed Netkit install directory
+CHECK_NETKIT_HOME=$(dirname "$PWD")
+
 # force language to avoid localization errors
 export LANG=C
 
@@ -85,8 +88,19 @@ parseOptions() {
    done
 }
 
-if [ ! -d "../bin" -o ! -d "../fs" -o ! -d "../kernel" -o ! -d "../man" -o ! -d "check_configuration.d" ]; then
-   echo "Netkit does not appear to be installed in \"$PWD\"."
+if [ "$(basename "$PWD")" != "setup_scripts" ]; then
+   echo "Please run this script from inside the setup_scripts subdirectory of the Netkit"
+   echo "install directory."
+   echo
+   exit 1
+fi
+
+if [ ! -d "${CHECK_NETKIT_HOME}/bin" \
+     -o ! -d "${CHECK_NETKIT_HOME}/fs" \
+     -o ! -d "${CHECK_NETKIT_HOME}/kernel" \
+     -o ! -d "${CHECK_NETKIT_HOME}/man" \
+     -o ! -d "check_configuration.d" ]; then
+   echo "Netkit does not appear to be installed in \"$CHECK_NETKIT_HOME\"."
    echo "Please run this script from inside the directory Netkit is installed in."
    echo
    exit 1


### PR DESCRIPTION
`check_configuration.sh` must be run inside `$NETKIT_HOME/setup_scripts`. The current implementation assumes it is ran inside `$NETKIT_HOME`, so all of the suggested checks and fixes for the `NETKIT_HOME` variable assume it should be the user's current directory, when it should actually be `setup_scripts/../` (`$PWD/..`).

Some issues were addressed in commit e2e83c58a90cc5cf3d08619482cc9b968fe654ec, however only the checks were, not ones in the fixes echo'ed to the user.

Also added is a check that the script is, indeed, running inside `setup_scripts`.