### PR TITLE
Replace misleading command suggestion in install-netkit-jh.sh

### DIFF
--- a/install-netkit-jh.sh
+++ b/install-netkit-jh.sh
@@ -206,7 +206,6 @@ fi
 # check netkit install now works
 # TODO: Get this to work... Netkit installs fine, but the check-configurator script doesn't read the environment variables properly so thinks something is wrong
 source ~/.bashrc
-cd "${TARGET_INSTALL_DIR}"
 
 # ./check_configuration.sh
 # encourage user to set environment variables for the current bash terminal
@@ -216,7 +215,7 @@ echo "To make the netkit settings available in this terminal, run the following 
 echo "source ~/.bashrc"
 
 echo ""
-echo "Run source ~/.bashrc, or open a new terminal, and then run ${NETKIT_HOME}/setup_scripts/check_configuration.sh to ensure your Netkit installation works!"
+echo "Run source ~/.bashrc, or open a new terminal, and then run cd ${TARGET_INSTALL_DIR}/setup_scripts && check_configuration.sh to ensure your Netkit installation works!"
 
 echo ""
 echo -e "\033[1mRun ${TARGET_INSTALL_DIR}/setup_scripts/change_terminal.sh to change your terminal emulator (highly recommended!)\033[0m"


### PR DESCRIPTION
Sourcing `.bashrc` does not work on Ubuntu (and related) distributions. Because of this, `NETKIT_HOME` may not be set during the runtime of the install script. This leads to a suggestion of "[...] then run /setup_scripts/check_configuration.sh [...]" because `NETKIT_HOME` is empty.

This fixes that, by using `TARGET_INSTALL_DIR` (as per every other command in the script).

It also tells the user to `cd` to `setup_scripts` before running `check_configuration.sh` (which is required)