### PR TITLE
Improve install script

### DIFF
--- a/install-netkit-jh.sh
+++ b/install-netkit-jh.sh
@@ -1,7 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Download and install netkit-jh in home directory
 # Modified from Peter Norris' original install script
+
+#
+# Users experiencing issues during the installation process
+# should be able to report back with the exact command that
+# has failed.
+#
+set -e
 
 # Default variables
 VERSION="VERSION_NUMBER"


### PR DESCRIPTION
* Added `set -e` to ensure the install script does not fail silently. Whenever a command causes an error, the script will now exit. This should aid the Netkit dev team with debugging issues.
* Changed `#!/bin/bash` to `#!/usr/bin/env bash` to ensure the installation script does not assume `bash` is under `/bin`. Now it will check the `$PATH` for `bash`.