### PR TITLE
Make tmux a con0 option instead of a separate option - `VM_CON0=tmux`

### DIFF
--- a/core/bin/block-wrapper
+++ b/core/bin/block-wrapper
@@ -31,12 +31,12 @@ case "$TERM_TYPE" in
     xterm)         	xterm -e /bin/bash -c "echo \$$>$pidfile; $KERNELCMD";;
     wsl)            powershell.exe -Command "start wsl -ArgumentList @('--','echo', '\$$>$pidfile;', '$KERNELCMD')";;
     tmux)
-        tmux -L netkit has-session -t "$VM_NAME" 2>/dev/null
+        tmux -L netkit has-session -t="$VM_NAME" 2>/dev/null
         if [ $? == 0 ]; then
-            read -r -p "tmux session already exists for this machine. kill session? [y/N] " response
+            read -r -p "tmux session already exists for machine $VM_NAME. kill session? [y/N] " response
             case "$response" in
             [yY][eE][sS]|[yY]) 
-                tmux -L netkit -t kill-session "$VM_NAME"
+                tmux -L netkit kill-session -t="$VM_NAME"
                 ;;
             *)
                 echo "tmux session in use - not starting $VM_NAME"

--- a/core/bin/block-wrapper
+++ b/core/bin/block-wrapper
@@ -33,13 +33,13 @@ case "$TERM_TYPE" in
     tmux)
         tmux -L netkit has-session -t "$VM_NAME" 2>/dev/null
         if [ $? == 0 ]; then
-            read -r -p "[block-wrapper]: tmux session already exists for this machine. kill session? [y/N] " response
+            read -r -p "tmux session already exists for this machine. kill session? [y/N] " response
             case "$response" in
             [yY][eE][sS]|[yY]) 
                 tmux -L netkit -t kill-session "$VM_NAME"
                 ;;
             *)
-                echo "[block-wrapper]: tmux session in use - not starting $VM_NAME"
+                echo "tmux session in use - not starting $VM_NAME"
                 exit
                 ;;
             esac
@@ -48,7 +48,7 @@ case "$TERM_TYPE" in
         ;;
 
 	*)
-                    echo "[block-wrapper]: terminal $TERM_TYPE not supported, defaulting to xterm."
+                    echo "Terminal $TERM_TYPE not supported, defaulting to xterm."
                     xterm -e /bin/bash -c "echo \$$>$pidfile; $KERNELCMD";;
 esac
 

--- a/core/bin/lstart
+++ b/core/bin/lstart
@@ -82,10 +82,10 @@ END_OF_HELP
    fi
    cat << END_OF_HELP
   --tmux-attached     Run each VM in tmux and start a terminal attached to the
-                      tmux session. This is the same as USE_TMUX=TRUE and
-                      TMUX_OPEN_TERMS=TRUE in netkit.conf
+                      tmux session. This is the same as VM_CON0=tmux and
+                      TMUX_OPEN_TERMS=yes in netkit.conf
   --tmux-detached     Run each VM in a tmux session without opening terminals.
-                      This is the same as USE_TMUX=TRUE and TMUX_OPEN_TERMS=FALSE
+                      This is the same as VM_CON0=tmux and TMUX_OPEN_TERMS=no
                       in netkit.conf
   -l, --list          Show a list of running virtual machines after starting
                       up the lab.

--- a/core/bin/script_utils
+++ b/core/bin/script_utils
@@ -53,8 +53,7 @@ export LANG=C
 : ${MAX_SIMULTANEOUS_VMS:=5}
 : ${GRACE_TIME:=0}
 : ${USE_SUDO:="yes"}
-: ${USE_TMUX:="FALSE"}
-: ${TMUX_OPEN_TERMS:="FALSE"}
+: ${TMUX_OPEN_TERMS:="no"}
 : ${CHECK_FOR_UPDATES:="yes"}
 : ${UPDATE_CHECK_PERIOD:=5}
 

--- a/core/bin/vcrash
+++ b/core/bin/vcrash
@@ -459,21 +459,21 @@ fi
 # Kill Tmux Sessions
 for VM in $VM_IDS; do
   if echo $1 | grep -qE "^[0-9]+$"; then
-    [ -z "$BE_QUIET" ] && echo "[vcrash]: cannot check tmux session using pid.
-    You may want to manuallykill any tmux session for the machine you are trying
+    [ -z "$BE_QUIET" ] && echo "Cannot check tmux session using pid.
+    You may want to manually kill any tmux session for the machine you are trying
     to crash (including MACHINE-dead sessions)"
   else
-    [ -z "$BE_QUIET" ] && echo "[vcrash]: Checking for $VM tmux session"
+    [ -z "$BE_QUIET" ] && echo "Checking for $VM tmux session"
     tmux -L netkit has-session -t="$VM" 2>/dev/null
     if [ $? -eq 0 ]; then
-       [ -z "$BE_QUIET" ] && echo "[vcrash]: Killing tmux session $VM"
+       [ -z "$BE_QUIET" ] && echo "Killing tmux session $VM"
        tmux -L netkit kill-session -t="$VM"
        exit 1
     fi
-    [ -z "$BE_QUIET" ] && echo "[vcrash]: Checking for ${VM}-dead tmux session"
+    [ -z "$BE_QUIET" ] && echo "Checking for ${VM}-dead tmux session"
     tmux -L netkit has-session -t="${VM}-dead" 2>/dev/null
     if [ $? -eq 0 ]; then
-       [ -z "$BE_QUIET" ] && echo "[vcrash]: Killing tmux session ${VM}-dead"
+       [ -z "$BE_QUIET" ] && echo "Killing tmux session ${VM}-dead"
        tmux -L netkit kill-session -t="${VM}-dead"
        exit 1
     fi

--- a/core/bin/vstart
+++ b/core/bin/vstart
@@ -331,12 +331,12 @@ parseCmdLine() {
 
          --tmux-attached)
             VM_CON0="tmux"
-            TMUX_OPEN_TERMS=TRUE
+            TMUX_OPEN_TERMS=yes
             ;;
             
          --tmux-detached)
             VM_CON0="tmux"
-            TMUX_OPEN_TERMS=FALSE
+            TMUX_OPEN_TERMS=no
             ;;
             
          -F|--foreground)
@@ -776,6 +776,6 @@ fi
 
 run_command "$JUST_PRINT" "$KERNELCMD" "{ $WAKEUP_PORTHELPER $REMOVE_FS_COMMAND $KERNELCMD; cleanHubs $HUBLIST; } $REDIRECT_CONSOLE $BACKGROUND"
 
-if [ "$TMUX_OPEN_TERMS" = "TRUE" ] && [ "$VM_CON0" = "tmux" ]; then
+if [ "$TMUX_OPEN_TERMS" = "yes" ] && [ "$VM_CON0" = "tmux" ]; then
     vconnect -m "$VM_NAME" --terminal --interval 5 --retry-count 20 &> /dev/null &
 fi

--- a/core/bin/vstart
+++ b/core/bin/vstart
@@ -169,10 +169,10 @@ Other options are:
                         this option. This is the default when using --con0=this
                         or --con1=this.
   --tmux-attached       Run each VM in tmux and start a terminal attached to the
-                        tmux session. This is the same as USE_TMUX=TRUE and
-                        TMUX_OPEN_TERMS=TRUE in netkit.conf
+                        tmux session. This is the same as VM_CON0=tmux and
+                        TMUX_OPEN_TERMS=yes in netkit.conf
   --tmux-detached       Run each VM in a tmux session without opening terminals.
-                        This is the same as USE_TMUX=TRUE and TMUX_OPEN_TERMS=FALSE
+                        This is the same as VM_CON0=tmux and TMUX_OPEN_TERMS=no
                         in netkit.conf
   -h, --help            Show this help.
   -p, --print           Do not actually start anything. Just show which commands
@@ -451,7 +451,7 @@ if containsRegexp PWD " "; then
 fi
 
 # Check whether the requested terminal emulator application exists
-if [ $VM_CON0 = "xterm" -o $VM_CON1 = "xterm" ]; then
+if [ "$VM_CON0" = "xterm" -o "$VM_CON1" = "xterm" ] || [ "$VM_CON0" = "tmux" -a "$TMUX_OPEN_TERMS" = "yes" ]; then
    # Look for user specified terminal application or, if none has been specified,
    # search for the standard xterm.
    TERMINAL_APPLICATION=${TERM_TYPE:-xterm}
@@ -736,6 +736,7 @@ if [ "$VM_CON0" = "xterm" -o "$VM_CON0" = "this_noporthelper"]; then
     KERNELCMD="$NETKIT_HOME/bin/block-wrapper $TERM_TYPE $VM_NAME $KERNELCMD"
 fi
 
+# Set up tmux
 if [ "$VM_CON0" = "tmux" ]; then
    if ! which tmux > /dev/null 2>&1; then
       warning "$SCRIPTNAME" "$CMDLINE" "$0" \

--- a/core/bin/vstart
+++ b/core/bin/vstart
@@ -330,12 +330,12 @@ parseCmdLine() {
             KERNEL_APPEND="$KERNEL_APPEND $CURRENT_ARGUMENT";;
 
          --tmux-attached)
-            USE_TMUX=TRUE
+            VM_CON0="tmux"
             TMUX_OPEN_TERMS=TRUE
             ;;
             
          --tmux-detached)
-            USE_TMUX=TRUE
+            VM_CON0="tmux"
             TMUX_OPEN_TERMS=FALSE
             ;;
             
@@ -731,16 +731,18 @@ fi
 
 [ -z "$BE_QUIET" ] && echo
 
-#### Start the kernel command in a tmux session
-[ "$USE_TMUX" = "TRUE" ] && TERM_TYPE="tmux"
-
-if [ "$VM_CON0" = "this" ] & [ "$USE_TMUX" = "TRUE" ]; then
-    echo "Using tmux with con0=this is currently unsupported."
+# Add our blocking script to the execution order
+if [ "$VM_CON0" = "xterm" -o "$VM_CON0" = "this_noporthelper"]; then
+    KERNELCMD="$NETKIT_HOME/bin/block-wrapper $TERM_TYPE $VM_NAME $KERNELCMD"
 fi
 
-# Add our blocking script to the execution order
-if [ "$VM_CON0" = "xterm" -o "$VM_CON0" = "this_noporthelper" -o "$USE_TMUX" = "TRUE" ]; then
-    KERNELCMD="$NETKIT_HOME/bin/block-wrapper $TERM_TYPE $VM_NAME $KERNELCMD"
+if [ "$VM_CON0" = "tmux" ]; then
+   if ! which tmux > /dev/null 2>&1; then
+      warning "$SCRIPTNAME" "$CMDLINE" "$0" \
+               "tmux appears not to be installed. Exiting."
+      exit 1
+   fi
+    KERNELCMD="$NETKIT_HOME/bin/block-wrapper tmux $VM_NAME $KERNELCMD"
 fi
 
 ##### Actually start network hubs
@@ -773,6 +775,6 @@ fi
 
 run_command "$JUST_PRINT" "$KERNELCMD" "{ $WAKEUP_PORTHELPER $REMOVE_FS_COMMAND $KERNELCMD; cleanHubs $HUBLIST; } $REDIRECT_CONSOLE $BACKGROUND"
 
-if [ "$TMUX_OPEN_TERMS" = "TRUE" ] && [ "$USE_TMUX" = "TRUE" ]; then
+if [ "$TMUX_OPEN_TERMS" = "TRUE" ] && [ "$VM_CON0" = "tmux" ]; then
     vconnect -m "$VM_NAME" --terminal --interval 5 --retry-count 20 &> /dev/null &
 fi

--- a/core/bin/vstart
+++ b/core/bin/vstart
@@ -732,7 +732,7 @@ fi
 [ -z "$BE_QUIET" ] && echo
 
 # Add our blocking script to the execution order
-if [ "$VM_CON0" = "xterm" -o "$VM_CON0" = "this_noporthelper"]; then
+if [ "$VM_CON0" = "xterm" -o "$VM_CON0" = "this_noporthelper" ]; then
     KERNELCMD="$NETKIT_HOME/bin/block-wrapper $TERM_TYPE $VM_NAME $KERNELCMD"
 fi
 

--- a/core/man/man1/lstart.1
+++ b/core/man/man1/lstart.1
@@ -81,14 +81,14 @@ the \fB\-p\fR option.
 .TP
 .B
 \-\-tmux\-attached
-Run each VM in a tmux session and start a terminal attached to this tmux session. This is the same as setting USE_TMUX=TRUE and TMUX_OPEN_TERMS=TRUE in netkit.conf
+Run each VM in a tmux session and start a terminal attached to this tmux session. This is the same as setting VM_CON0=tmux and TMUX_OPEN_TERMS=yes in netkit.conf
 
 .TP
 .PD 0
 .TP
 .B
 \-\-tmux\-detached
-Run each VM in a tmux session without opening any terminals. This is the same as setting USE_TMUX=TRUE and TMUX_OPEN_TERMS=FALSE in netkit.conf
+Run each VM in a tmux session without opening any terminals. This is the same as setting VM_CON0=tmux and TMUX_OPEN_TERMS=no in netkit.conf
 
 .TP
 .B

--- a/core/man/man1/vstart.1
+++ b/core/man/man1/vstart.1
@@ -304,6 +304,12 @@ until the first connection is established. Notice that, if the connection is clo
 while the virtual machine is still running, it won't be possible to access the console
 by telnetting again to \fItcp\-port\fR. In such a case, the virtual machine
 can still be halted by using one of the commands \fBvhalt\fR or \fBvcrash\fR.
+
+.TP
+.B
+tmux
+Start the VM within a tmux session.
+
 .TP
 .B
 none
@@ -447,14 +453,14 @@ Regardless of this option, virtual hubs are always started in background.
 .TP
 .B
 \-\-tmux\-attached
-Run each VM in a tmux session and start a terminal attached to this tmux session. This is the same as setting USE_TMUX=TRUE and TMUX_OPEN_TERMS=TRUE in netkit.conf
+Run each VM in a tmux session and start a terminal attached to this tmux session. This is the same as setting VM_CON0=tmux and TMUX_OPEN_TERMS=yes in netkit.conf
 
 .TP
 .PD 0
 .TP
 .B
 \-\-tmux\-detached
-Run each VM in a tmux session without opening any terminals. This is the same as setting USE_TMUX=TRUE and TMUX_OPEN_TERMS=FALSE in netkit.conf
+Run each VM in a tmux session without opening any terminals. This is the same as setting VM_CON0=tmux and TMUX_OPEN_TERMS=no in netkit.conf
 
 .TP
 .B

--- a/core/man/man5/netkit.conf.5
+++ b/core/man/man5/netkit.conf.5
@@ -244,6 +244,12 @@ happen to accidentally disconnect before halting the virtual machine, you can
 still stop it by using either \fIvhalt\fR or \fIvcrash\fR (see \fBvhalt\fR,
 \fBvcrash\fR).
 
+.TP
+.B
+tmux
+Start the VM within a tmux session.
+
+
 .PP
 \fIvstart options\fR: \fB\-\-con0\fR, \fB\-\-con1\fR
 .br
@@ -254,43 +260,25 @@ still stop it by using either \fIvhalt\fR or \fIvcrash\fR (see \fBvhalt\fR,
 
 .TP
 .B
-USE_TMUX
-Run the vm inside a tmux session on the host this means you can then
-connect and disconnect from it when you want (using the vconnect
-command) and send commands to it with vcommand.
-
-.RS
-.TP
-.B
-TRUE
-Run VM in tmux session.
-
-.RS
-.TP
-.B
-FALSE
-Do not run VM in tmux session.
-
-.TP
-.B
 TMUX_OPEN_TERMS
 Open a terminal with the tmux session for the machine this will run
-vconnect in the background to attempt to connect. N.b. this has a
-timeout - if the tmux session fails to open this will eventually
-stop polling it. This option only takes effect when USE_TMUX is true.
+vconnect in the background to attempt to connect. This uses the terminal set
+by the TERM_TYPE option.
+N.b. this has a timeout - if the tmux session fails to open this will eventually
+stop polling it. This option only takes effect when VM_CON0 is set to 'tmux'.
 
 .RS
 .TP
 .B
-TRUE
+yes
 Attempt to open a terminal connected to the tmux session for the machine.
 
-.RS
 .TP
 .B
-FALSE
+no
 No terminals are opened. You can connect to the machine manually
 with vconnect.
+.RE
 
 
 .TP

--- a/core/netkit.conf
+++ b/core/netkit.conf
@@ -40,6 +40,10 @@ VM_CON1=none                    # Virtual machine secondary consoles are disable
                                 # none, xterm, this, pty, port:port_number
 CON0_PORTHELPER=no              # Bypass port-helper (debugging option)
 
+USE_TMUX=FALSE                  # Run the vm inside a tmux session on the host
+                                # this means you can then connect and disconnect from it 
+                                # when you want (using the vconnect command) and send
+                                # commands to it with vcommand.
 TMUX_OPEN_TERMS=FALSE           # Open a terminal with the tmux session for the machine
                                 # this will run vconnect in the background to attempt to 
                                 # connect. N.b. this has a timeout - if the tmux session

--- a/core/netkit.conf
+++ b/core/netkit.conf
@@ -37,18 +37,15 @@ VM_KERNEL="$NETKIT_HOME/kernel/netkit-kernel"  # Virtual machine kernel
 VM_CON0=xterm                   # Virtual machine primary consoles use XTerms.
 VM_CON1=none                    # Virtual machine secondary consoles are disabled.
                                 # Allowed values for VM_CON0 and VM_CON1 are:
-                                # none, xterm, this, pty, port:port_number
+                                # none, xterm, this, pty, port:port_number, tmux
 CON0_PORTHELPER=no              # Bypass port-helper (debugging option)
 
-USE_TMUX=FALSE                  # Run the vm inside a tmux session on the host
-                                # this means you can then connect and disconnect from it 
-                                # when you want (using the vconnect command) and send
-                                # commands to it with vcommand.
-TMUX_OPEN_TERMS=FALSE           # Open a terminal with the tmux session for the machine
+
+TMUX_OPEN_TERMS=no              # Open a terminal with the tmux session for the machine
                                 # this will run vconnect in the background to attempt to 
                                 # connect. N.b. this has a timeout - if the tmux session
                                 # fails to open this will eventually stop polling it.
-                                # This option only takes effect when USE_TMUX is true
+                                # This option only takes effect when VM_CON0=tmux
 
 TERM_TYPE=xterm                 # Virtual machine consoles will use this terminal
                                 # emulator. Allowed values for TERM_TYPE are:

--- a/core/netkit.conf
+++ b/core/netkit.conf
@@ -40,10 +40,6 @@ VM_CON1=none                    # Virtual machine secondary consoles are disable
                                 # none, xterm, this, pty, port:port_number
 CON0_PORTHELPER=no              # Bypass port-helper (debugging option)
 
-USE_TMUX=FALSE                  # Run the vm inside a tmux session on the host
-                                # this means you can then connect and disconnect from it 
-                                # when you want (using the vconnect command) and send
-                                # commands to it with vcommand.
 TMUX_OPEN_TERMS=FALSE           # Open a terminal with the tmux session for the machine
                                 # this will run vconnect in the background to attempt to 
                                 # connect. N.b. this has a timeout - if the tmux session

--- a/core/setup_scripts/check_configuration.d/07-check_terminal_emulators.sh
+++ b/core/setup_scripts/check_configuration.d/07-check_terminal_emulators.sh
@@ -40,7 +40,7 @@ PATH_TO_BE_USED=":"
 
 XTERM_WARNING=0
 
-TERMINAL_EMULATORS="xterm konsole gnome-terminal alacritty kitty wsl.exe"
+TERMINAL_EMULATORS="xterm konsole gnome-terminal alacritty kitty wsl.exe tmux"
 
 for CURRENT_COMMAND in $TERMINAL_EMULATORS; do
    printf "\t%-15s: " $CURRENT_COMMAND

--- a/core/setup_scripts/handle_config.sh
+++ b/core/setup_scripts/handle_config.sh
@@ -80,3 +80,25 @@ if [ "${CURRENT_VERSION}" -lt 4 ]; then
     CURRENT_VERSION=4
     sed -i "s/CONFIG_VERSION=3/CONFIG_VERSION=4/g" ${NEW_DIR}/netkit.conf
 fi
+
+# Upgrade from v4 to v5
+# - Sets mconsole dir to machines again due to broken V3 configuration
+if [ "${CURRENT_VERSION}" -lt 5 ]; then
+    echo "Upgrading Netkit configuration to V5."
+
+    # Add tmux to the list of valid options for VM_CON0
+    sed -i '/^\s*\# none, xterm, this, pty, port:port_number/ s/$/, tmux/' ${NEW_DIR}/netkit.conf
+
+    # Remove USE_TMUX section as con0 is now used to handle tmux
+    sed -i ':a;N;$!ba;s/USE_TMUX=FALSE.*commands to it with vcommand.//g' ${NEW_DIR}/netkit.conf
+
+    # Update TMUX_OPEN_TERMS to yes/no instead of TRUE/FALSE
+    sed -i 's/^TMUX_OPEN_TERMS=FALSE/TMUX_OPEN_TERMS=no   /g' ${NEW_DIR}/netkit.conf
+
+    # Update comment for TMUX_OPEN_TERMS to reflect change from USE_TMUX to VM_CON0
+    sed -i 's/# This option only takes effect when USE_TMUX is true/# This option only takes effect when VM_CON0=tmux/g' ${NEW_DIR}/netkit.conf
+	
+    # Finally, update the version.
+    CURRENT_VERSION=4
+    sed -i "s/CONFIG_VERSION=3/CONFIG_VERSION=4/g" ${NEW_DIR}/netkit.conf
+fi


### PR DESCRIPTION
tmux can now be used as a con0 option - which can be enabled with `VM_CON0=tmux` instead of the old `USE_TMUX=TRUE`

`TMUX_OPEN_TERMS` now uses `yes || no` instead of `TRUE || FALSE`, for consistency with other variables.

This should fix problems with `con0=this`, `con0=none` etc

pls test this and consider a beta release before i end up breaking more stuff