### PR TITLE
Add glibc warning message inside check_architecture

### DIFF
--- a/core/setup_scripts/check_configuration.d/09-check_architecture.sh
+++ b/core/setup_scripts/check_configuration.d/09-check_architecture.sh
@@ -38,6 +38,7 @@ if ! $NETKIT_HOME/kernel/netkit-kernel --help >/dev/null 2>&1; then
    echo "failed!"
    echo
    echo "*** Error: Your system appears not to be able to run the linux kernel."
+   echo "Ensure your Linux system has glibc version 2.28 or higher by running 'ldd --version'"
    echo
    check_failure
 fi


### PR DESCRIPTION
Add a new line to the error message on the check architecture script to suggest a reason for the failure to the user.