### PR TITLE
Prevent `source ./.<shell>rc` failure

### DIFF
--- a/install-netkit-jh.sh
+++ b/install-netkit-jh.sh
@@ -174,9 +174,7 @@ else
 	tar -xjvC "${TARGET_INSTALL_DIR}" --strip-components=1 -f ${DOWNLOAD_DIR}/netkit-kernel-${VERSION}.tar.bz2
 fi
 
-BASHRC="${HOME}/.bashrc"
-ZSHRC="${HOME}/.zshrc"
-RC_FILES=("$BASHRC" "$ZSHRC")
+RC_FILES=("${HOME}/.bashrc" "${HOME}/.zshrc")
 
 for RC_FILE in "${RC_FILES[@]}"; do
 	# Check whether this file exists

--- a/install-netkit-jh.sh
+++ b/install-netkit-jh.sh
@@ -174,7 +174,10 @@ else
 	tar -xjvC "${TARGET_INSTALL_DIR}" --strip-components=1 -f ${DOWNLOAD_DIR}/netkit-kernel-${VERSION}.tar.bz2
 fi
 
-RC_FILES=("${HOME}/.bashrc" "${HOME}/.zshrc")
+BASHRC="${HOME}/.bashrc"
+ZSHRC="${HOME}/.zshrc"
+RC_FILES=("$BASHRC" "$ZSHRC")
+
 for RC_FILE in "${RC_FILES[@]}"; do
 	# Check whether this file exists
 	if [ ! -f ${RC_FILE} ]; then
@@ -196,10 +199,6 @@ for RC_FILE in "${RC_FILES[@]}"; do
 
 	# Append Netkit additions to bashrc  
 	echo "$NK_ENV_VARS" >> "${RC_FILE}"
-
-	# Set the environment variables so ./check_configuration.sh can be ran
-	source "${RC_FILE}"
-
 done
 
 # make (for lab.dep) and net-tools (for tap) needed on ubuntu 18.04


### PR DESCRIPTION
Hosts with multiple shell environments may have source files that fail when sourced under a different shell.
Currently, to enable a successful `./check-configuration.sh` on installation, `.zshrc` and `.bashrc` are sourced if they exist. So if running in Zsh, `source .bashrc` is still ran which may fail with shell-specific commands (and vice versa).

The issue is fixed by just removing it. Line 222 in this PR makes it redundant - the environment variables are exported with the `eval` statement.