### PR TITLE
Increase default `MAX_SIMULTANEOUS_VMS` config var

### DIFF
--- a/core/netkit.conf
+++ b/core/netkit.conf
@@ -59,7 +59,7 @@ MAX_MEM=512                     # Maximum amount of memory for virtual machines
                                 # (megabytes)
 
 # lcommands defaults
-MAX_SIMULTANEOUS_VMS=5          # Maximum number of simultaneously started virtual
+MAX_SIMULTANEOUS_VMS=20         # Maximum number of simultaneously started virtual
                                 # machines. Only significant when using parallel
                                 # startup. This parameter must be set to some
                                 # positive integer. Set it to 0 in order to set


### PR DESCRIPTION
Done some testing and there's no disadvantage to increasing the maximum number of machines on parallel startup. It seems to use 100% of your CPU regardless of the number of VMs starting up, and memory usage only increases by the number of machines present. Setting it to `0` may be up for debate though?