### PR TITLE
[WIP] Convert man pages into Markdown for scdoc

### DIFF
--- a/core/man/man1/lclean.1.scd
+++ b/core/man/man1/lclean.1.scd
@@ -1,0 +1,94 @@
+lclean(1)
+
+# NAME
+
+lclean - clean temporary files created after launching netkit lab
+
+# SYNOPSIS
+
+*lclean* \[options\] \[_MACHINE-NAME_\...\]
+
+# DESCRIPTION
+
+**lclean** can be used to delete temporary files that have been created
+while running a Netkit lab. Some of the them are specific for each
+virtual machine, while others are unique for the whole lab. Some are
+written inside the directory from which _lstart_ has been invoked, while
+others are placed inside the lab directory.\
+Assuming that _lab-path_ is the directory where the lab is located,
+*lclean* deletes the following files, if found to exist:
+
+- ./_machine-name_.ready
+- ./_machine-name_.disk
+- ./_machine-name_.log (no longer produced by latest releases, but still removed for backwards compatibility)
+- _lab-path_/readyfor.test
+
+If invoked with no arguments, *lclean* removes temporary files for all
+the virtual machines that make up the lab (i.e., _machine-name_ is
+replaced by the name of each virtual machine). It is also possible to
+provide a list of *MACHINE\-NAME*s, in which case _lclean_ just removes
+temporary files for those virtual machines (as well as the `readyfor.test`
+file).
+
+Removing virtual machines COW filesystems (.disk files) implies that
+virtual machines contents are reverted to their original state when the
+lab is restarted. Of course, any persistent part of the lab is
+preserved, including those files that are automatically copied inside
+virtual machines during the boot phase.
+
+See the README file in the Netkit filesystem package for more
+information about COW filesystems.
+
+The following options are supported by *lclean*:
+
+*-d* _DIRECTORY_
+	Assume the Netkit lab that is located inside _DIRECTORY_. If no *-d*
+	option is provided, *lclean* assumes that the lab is located in the
+	current directory. The path to the lab directory (being that the
+	current directory or one provided by *-d*) must never contain spaces.
+
+	This piece of information is necessary in order to remove some of the
+	temporary files and to retrieve the list of the virtual machines that
+	make up the lab.
+
+The following standard options are also supported.
+
+*-h*, *--help*
+	Show usage information.
+
+*-v*, *--verbose*
+	Show which files are being deleted.
+
+*\--version*
+	Print information about the installed Netkit release and the host
+	kernel version and exit. If \`\`_<unavailable>_\'\' is printed
+	instead of a version number, then the corresponding information
+	could not be retrieved (for example because a non-standard Netkit
+	kernel or filesystem is being used).
+
+# ENVIRONMENT VARIABLES
+
+All Netkit commands require that the *NETKIT\_HOME* variable contains
+the name of the directory Netkit is installed in.
+
+Apart from this, *lclean* supports no other environment variables.
+
+# NOTES
+
+Despite the fact that the two command names sound similar, *lclean* has
+nothing to do with *vclean*(1). While *lclean* is a tool to get rid of
+temporary files inside a Netkit lab directory (i.e., it works on the
+host filesystem), *vclean*(1) is the Netkit \`\`panic button\'\',
+which allows to kill hanging processes and to restore settings that may
+have been altered by Netkit during past executions (firewall settings,
+configurations set up for tap interfaces, etc.).
+
+# SEE ALSO
+
+*lstart*(1), *lcrash*(1), *lhalt*(1), *lrestart*(1), *linfo*(1),
+*ltest*(1), *vclean*(1), Netkit filesystem README.
+
+# AUTHOR
+
+*lclean* script: Stefano Pettini, Fabio Ricci, Massimo Rimondini\
+This man page: Fabio Ricci, Massimo Rimondini

--- a/core/man/man1/lhalt.1.scd
+++ b/core/man/man1/lhalt.1.scd
@@ -1,0 +1,82 @@
+lhalt(1)
+
+# NAME
+
+lhalt - halt machines of a netkit lab
+
+# SYNOPSIS
+
+*lhalt* \[options\] \[_MACHINE-NAME_\...\]
+
+# DESCRIPTION
+
+The _lhalt_ command can be used to gracefully shut down virtual machines
+of a Netkit lab. *lhalt* makes use of *vhalt* to halt virtual machines
+(see *vhalt*(1)).
+
+By default, _vhalt_ stops all the virtual machines of the lab. If a list
+of *MACHINE-NAME*s is provided, then only virtual machines with a
+matching name *and* that are part of the lab will be halted.
+
+The following options are supported by _lhalt_:
+
+*-d* _DIRECTORY_
+	Halt the Netkit lab that is located inside *DIRECTORY*. If no *-d*
+	option is provided, *lhalt* assumes that the lab is located in the
+	current directory. The path to the lab directory (being that the
+	current directory or one provided by *-d*) must never contain
+	spaces.
+
+*-l*, *--list*
+	Show a list of currently running virtual machines after the lab has
+	been halted. This is useful to check whether all the hosts have been
+	shut down.
+
+*-q*, *--quick*, *--quiet*
+	This option prevents *lhalt* from checking whether virtual machines
+	have properly halted. Hence, it speeds up the halt process. Notice
+	that, unlike *lcrash* (see *lcrash*(1)), a shutdown fails or
+	succeeds regardless of the use of this option (i.e., no benefit is
+	gained from retrying without this option). This option slightly
+	reduces the output of *lhalt* as well.\
+	This option is incompatible with *-r* or *--remove-fs*.
+
+*-r*, *--remove-fs*
+	Delete virtual machines (COW) filesystems (.disk files) after
+	halting the corresponding machines. Default action is to keep the
+	filesystems, so that the lab can be restarted while preserving
+	filesystem contents.\
+	Using this option never affects the model filesystem. This option is
+	incompatible with *-q* (*--quick*, *--quiet*).
+
+	See the README in the Netkit filesystem package for information about
+	COW and model filesystems.
+
+The following standard options are also supported.
+
+*-h*, *--help*
+	Show usage information.
+
+*--version*
+	Print information about the installed Netkit release and the host
+	kernel version and exit. If \`\`_\<unavailable\>_\'\' is printed
+	instead of a version number, then the corresponding information
+	could not be retrieved (for example because a non-standard Netkit
+	kernel or filesystem is being used).
+
+# ENVIRONMENT VARIABLES
+
+All Netkit commands require that the *NETKIT\_HOME* variable contains
+the name of the directory Netkit is installed in.
+
+Apart from this, *lhalt* supports no other environment variables.
+
+# SEE ALSO
+
+*lstart*(1), *lclean*(1), *lcrash*(1), *lrestart*(1), *linfo*(1),
+*ltest*(1), *vhalt*(1), Netkit filesystem README.
+
+# AUTHOR
+
+*lhalt* script: Stefano Pettini, Massimo Rimondini\
+This man page: Fabio Ricci, Massimo Rimondini

--- a/core/man/man1/lrestart.1.scd
+++ b/core/man/man1/lrestart.1.scd
@@ -1,0 +1,198 @@
+lstart(1)
+
+# NAME
+
+lstart - start a netkit lab
+
+# SYNOPSIS
+
+*lstart* \[options\] \[_MACHINE-NAME_\...\]
+
+*lrestart* \[options\] \[_MACHINE-NAME_\...\]
+
+# DESCRIPTION
+
+In order to ease setting up complex network experiences with Netkit it
+is possible to completely describe them into special configuration
+files, so that the experience can later be started with a single command
+as if it were a virtual network \`\`laboratory\'\'.
+
+The _lstart_ command can be used to achieve this purpose. In particular,
+it starts a set of virtual machines that are part of a Netkit lab and
+configures them according to the parameters contained in the lab
+description. There is no difference between _lstart_ and _lrestart_. The
+latter is just provided for backward compatibility.\
+By default, all the virtual machines that make up the lab are started.
+If a list of _MACHINE-NAME_s is provided, then only virtual machines
+with a matching name _and_ that are part of the lab are started.
+
+The configuration of a Netkit lab consists of some files and directories
+whose names, locations and contents are described in the page
+*lab.conf*(5).
+
+The following options are supported by _lstart_:
+
+*-d* _DIRECTORY_
+	Start the Netkit lab that is located inside _DIRECTORY_. If no
+	*-d* option is provided, _lstart_ assumes that the lab is located
+	in the current directory. The path to the lab directory (being that
+	the current directory or one provided by *-d*) must never contain
+	spaces.
+
+	Note that, in order to avoid starting undesired virtual machines,
+	_lstart_ checks whether the current directory (or the directory
+	specified with *-d*) contains at least a \`\`lab.conf\'\' or a
+	\`\`lab.dep\'\' file, and refuses to start the lab if none of these file
+	exists. See option *-F* below for disabling this behavior.
+
+*-F*, *--force-lab*
+	As a native behaviour, Netkit starts a virtual machine for each
+	directory that it finds in a designed path, by default the current
+	directory. In order to prevent the user from accidentally starting
+	random virtual machines from a directory that does not contain a
+	lab, lstart requires the presence of at least a \`\`lab.conf\'\' or
+	a \`\`lab.dep\'\' file in the affected directory. If these files are
+	not required for your setting, and you still want to launch your lab
+	without creating either one, you can use option *-F* or *--force-lab*
+	to convince Netkit that a certain directory is indeed a lab.
+
+*-f*, *--fast*
+	_lstart_ always waits for a virtual machine to complete its boot
+	phase before launching the next one. This option disables this
+	behaviour, and allows to launch several virtual machines at once.\
+	This option has no effect if parallel startup is being used and is
+	not impacted by the *-p* option.
+
+*--tmux-attached*
+	Run each VM in a tmux session and start a terminal attached to this
+	tmux session. This is the same as setting USE\_TMUX=TRUE and
+	TMUX\_OPEN\_TERMS=TRUE in netkit.conf
+
+*--tmux-detached*
+	Run each VM in a tmux session without opening any terminals. This is
+	the same as setting USE\_TMUX=TRUE and TMUX\_OPEN\_TERMS=FALSE in
+	netkit.conf
+
+*-l*, *--list*
+	Show a list of currently running virtual machines after the lab has
+	been started up. This is useful to check whether all the hosts are
+	up and running. Notice that, when the *-f* (or *--fast*) option
+	is being used, _lstart_ does not wait for all the virtual machines
+	of the lab to start up before printing this list, resulting in a
+	possibly incomplete report. Hence, it is advised not to use *-l*
+	(or *--list*) together with *-f* (or *--fast*).
+
+*-o* _OPTION_, *--pass=*_OPTION_
+	_lstart_ acts as a frontend to *vstart* (see *vstart*(1)). This
+	option allows to pass an _OPTION_ unaltered to every invocation of
+	*vstart*. This means that all the virtual machines of the lab will
+	be launched with option _OPTION_. _OPTION_ should be specified
+	exactly as it would be on the *vstart* command line, but always
+	make sure that space characters are quoted (e.g., \`-fdummy.disk\'
+	or \`--append=debug\' are ok, \`-M 32\' should be written as either
+	\`-M32\' or \`\"-M 32\"\').
+
+*-p*\[_VALUE_\]**
+	Parallel startup is a special startup mode that allows to
+	simultaneously boot several virtual machines. It is automatically
+	enabled whenever a \`lab.dep\' file is found to exist inside the lab
+	directory. This option forces parallel startup, even if the
+	\`lab.dep\' file does not exist. In order to limit the load on your
+	host, this option also allows to set a maximum number of virtual
+	machines that at any time instant can be simultaneously booting.
+	_VALUE_ must be a positive integer. A _VALUE_ of 0 corresponds to
+	setting no limit. If no VALUE is provided, the default configured
+	inside _netkit.conf_ is assumed (see *netkit.conf*(5)).\
+	This option conflicts with *-s* (or *--sequential*).
+
+	This option overrides the default value of MAX\_SIMULTANEOUS\_VMS inside
+	_netkit.conf_ (see *netkit.conf*(5)).
+
+	*Notice*: parallel startup requires that the *make* utility is
+	properly installed on your system.
+
+*-s*, *--sequential*
+	Disable parallel startup, even if a \`lab.dep\' file is found to
+	exist in the lab directory. This option is useful when you just want
+	to launch specific virtual machines. In fact, if you just provide
+	their _MACHINE-NAME_s on the command line, _lstart_ would still
+	attempt to satisfy the dependencies, and this may result in starting
+	other undesired virtual machines.\
+	This option cannot be used together with *-p*.
+
+*-w* _SECONDS_, *--wait=*_SECONDS_
+	Wait for the specified amount of time before launching the next
+	virtual machine. This option is always enforced, but it just becomes
+	handy (for example, to reduce the load on the host machine) when
+	using either *-f* (or *--fast*) or parallel startup.
+
+	This option overrides the default value of GRACE\_TIME inside
+	_netkit.conf_ (see *netkit.conf*(5)).
+
+The following standard options are also supported.
+
+*-h*, *--help*
+	Show usage information.
+
+*-v*, *--verbose*
+	Show details about virtual machines while starting them.
+
+*--version*
+	Print information about the installed Netkit release and the host
+	kernel version and exit. If \`\`_\<unavailable\>_\'\' is printed
+	instead of a version number, then the corresponding information
+	could not be retrieved (for example because a non-standard Netkit
+	kernel or filesystem is being used).
+
+# FILES
+
+Apart from the lab configuration files, running a lab requires creating
+some temporary files inside the current directory (i.e., the one the
+_lstart_ command is executed from) as well as inside the lab directory.
+Such files are:
+
+_./machine_.ready
+	These files are created by _lstart_ and are used to synchronize
+	virtual machines when they are started. These files are
+	automatically deleted when all the machines in the lab have properly
+	started up. Yet, sometimes (e.g., when a virtual machine crashes in
+	the boot phase) there may be \`.ready\' files left in the current
+	directory even after the lab has been stopped. In this case you have
+	to launch *lclean* (see *lclean*(1)) to get rid of them before
+	the lab can be restarted.
+
+_./machine_.disk
+	This is the COW filesystem for virtual machine _machine_. These
+	files are automatically removed when the lab is crashed with
+	*lcrash* (see *lcrash*(1)), so that virtual machines can revert
+	to their original state when the lab is restarted. If you want to
+	preserve .disk files, use the *-F* (or *--keep-fs*) option of
+	*lcrash*. On the other hand, *lhalt*(1) (see *lhalt*(1)) never
+	removes .disk files, unless explicitly told to do it (with the
+	*-r* or *--remove-fs* option).
+
+	See the README in the Netkit filesystem package for more information
+	about COW filesystems.
+
+_lab-path_/readyfor.test
+	This file is automatically created by *ltest* (see *ltest*(1)).
+	It is used to ensure that the status of running virtual machines is
+	only retrieved when they have all completed their boot phase.
+
+# NOTES
+
+_lstart_ is essentially a wrapper for *vstart*. Hence, if something
+goes wrong, try to investigate the parameters used in the invocation of
+*vstart* (they are reported in the _lstart_ output) and read the
+*vstart*(1) documentation.
+
+# SEE ALSO
+
+_lab.conf_(5), _lclean_(1), _lhalt_(1), _lcrash_(1), _linfo_(1),
+_ltest_(1), _make_(1), _vstart_(1), _netkit.conf_(5), Netkit filesystem
+README.
+
+# AUTHOR
+
+_lstart_ script: Stefano Pettini, Fabio Ricci, Massimo Rimondini\
+This man page: Fabio Ricci, Massimo Rimondini

--- a/core/man/man1/lstart.1.scd
+++ b/core/man/man1/lstart.1.scd
@@ -1,0 +1,198 @@
+lstart(1)
+
+# NAME
+
+lstart - start a netkit lab
+
+# SYNOPSIS
+
+*lstart* \[options\] \[_MACHINE-NAME_\...\]
+
+*lrestart* \[options\] \[_MACHINE-NAME_\...\]
+
+# DESCRIPTION
+
+In order to ease setting up complex network experiences with Netkit it
+is possible to completely describe them into special configuration
+files, so that the experience can later be started with a single command
+as if it were a virtual network \`\`laboratory\'\'.
+
+The _lstart_ command can be used to achieve this purpose. In particular,
+it starts a set of virtual machines that are part of a Netkit lab and
+configures them according to the parameters contained in the lab
+description. There is no difference between _lstart_ and _lrestart_. The
+latter is just provided for backward compatibility.\
+By default, all the virtual machines that make up the lab are started.
+If a list of _MACHINE-NAME_s is provided, then only virtual machines
+with a matching name _and_ that are part of the lab are started.
+
+The configuration of a Netkit lab consists of some files and directories
+whose names, locations and contents are described in the page
+*lab.conf*(5).
+
+The following options are supported by _lstart_:
+
+*-d* _DIRECTORY_
+	Start the Netkit lab that is located inside _DIRECTORY_. If no
+	*-d* option is provided, _lstart_ assumes that the lab is located
+	in the current directory. The path to the lab directory (being that
+	the current directory or one provided by *-d*) must never contain
+	spaces.
+
+	Note that, in order to avoid starting undesired virtual machines,
+	_lstart_ checks whether the current directory (or the directory
+	specified with *-d*) contains at least a \`\`lab.conf\'\' or a
+	\`\`lab.dep\'\' file, and refuses to start the lab if none of these file
+	exists. See option *-F* below for disabling this behavior.
+
+*-F*, *--force-lab*
+	As a native behaviour, Netkit starts a virtual machine for each
+	directory that it finds in a designed path, by default the current
+	directory. In order to prevent the user from accidentally starting
+	random virtual machines from a directory that does not contain a
+	lab, lstart requires the presence of at least a \`\`lab.conf\'\' or
+	a \`\`lab.dep\'\' file in the affected directory. If these files are
+	not required for your setting, and you still want to launch your lab
+	without creating either one, you can use option *-F* or *--force-lab*
+	to convince Netkit that a certain directory is indeed a lab.
+
+*-f*, *--fast*
+	_lstart_ always waits for a virtual machine to complete its boot
+	phase before launching the next one. This option disables this
+	behaviour, and allows to launch several virtual machines at once.\
+	This option has no effect if parallel startup is being used and is
+	not impacted by the *-p* option.
+
+*--tmux-attached*
+	Run each VM in a tmux session and start a terminal attached to this
+	tmux session. This is the same as setting USE\_TMUX=TRUE and
+	TMUX\_OPEN\_TERMS=TRUE in netkit.conf
+
+*--tmux-detached*
+	Run each VM in a tmux session without opening any terminals. This is
+	the same as setting USE\_TMUX=TRUE and TMUX\_OPEN\_TERMS=FALSE in
+	netkit.conf
+
+*-l*, *--list*
+	Show a list of currently running virtual machines after the lab has
+	been started up. This is useful to check whether all the hosts are
+	up and running. Notice that, when the *-f* (or *--fast*) option
+	is being used, _lstart_ does not wait for all the virtual machines
+	of the lab to start up before printing this list, resulting in a
+	possibly incomplete report. Hence, it is advised not to use *-l*
+	(or *--list*) together with *-f* (or *--fast*).
+
+*-o* _OPTION_, *--pass=*_OPTION_
+	_lstart_ acts as a frontend to *vstart* (see *vstart*(1)). This
+	option allows to pass an _OPTION_ unaltered to every invocation of
+	*vstart*. This means that all the virtual machines of the lab will
+	be launched with option _OPTION_. _OPTION_ should be specified
+	exactly as it would be on the *vstart* command line, but always
+	make sure that space characters are quoted (e.g., \`-fdummy.disk\'
+	or \`--append=debug\' are ok, \`-M 32\' should be written as either
+	\`-M32\' or \`\"-M 32\"\').
+
+*-p*\[_VALUE_\]**
+	Parallel startup is a special startup mode that allows to
+	simultaneously boot several virtual machines. It is automatically
+	enabled whenever a \`lab.dep\' file is found to exist inside the lab
+	directory. This option forces parallel startup, even if the
+	\`lab.dep\' file does not exist. In order to limit the load on your
+	host, this option also allows to set a maximum number of virtual
+	machines that at any time instant can be simultaneously booting.
+	_VALUE_ must be a positive integer. A _VALUE_ of 0 corresponds to
+	setting no limit. If no VALUE is provided, the default configured
+	inside _netkit.conf_ is assumed (see *netkit.conf*(5)).\
+	This option conflicts with *-s* (or *--sequential*).
+
+	This option overrides the default value of MAX\_SIMULTANEOUS\_VMS inside
+	_netkit.conf_ (see *netkit.conf*(5)).
+
+	*Notice*: parallel startup requires that the *make* utility is
+	properly installed on your system.
+
+*-s*, *--sequential*
+	Disable parallel startup, even if a \`lab.dep\' file is found to
+	exist in the lab directory. This option is useful when you just want
+	to launch specific virtual machines. In fact, if you just provide
+	their _MACHINE-NAME_s on the command line, _lstart_ would still
+	attempt to satisfy the dependencies, and this may result in starting
+	other undesired virtual machines.\
+	This option cannot be used together with *-p*.
+
+*-w* _SECONDS_, *--wait=*_SECONDS_
+	Wait for the specified amount of time before launching the next
+	virtual machine. This option is always enforced, but it just becomes
+	handy (for example, to reduce the load on the host machine) when
+	using either *-f* (or *--fast*) or parallel startup.
+
+	This option overrides the default value of GRACE\_TIME inside
+	_netkit.conf_ (see *netkit.conf*(5)).
+
+The following standard options are also supported.
+
+*-h*, *--help*
+	Show usage information.
+
+*-v*, *--verbose*
+	Show details about virtual machines while starting them.
+
+*--version*
+	Print information about the installed Netkit release and the host
+	kernel version and exit. If \`\`_\<unavailable\>_\'\' is printed
+	instead of a version number, then the corresponding information
+	could not be retrieved (for example because a non-standard Netkit
+	kernel or filesystem is being used).
+
+# FILES
+
+Apart from the lab configuration files, running a lab requires creating
+some temporary files inside the current directory (i.e., the one the
+_lstart_ command is executed from) as well as inside the lab directory.
+Such files are:
+
+_./machine_.ready
+	These files are created by _lstart_ and are used to synchronize
+	virtual machines when they are started. These files are
+	automatically deleted when all the machines in the lab have properly
+	started up. Yet, sometimes (e.g., when a virtual machine crashes in
+	the boot phase) there may be \`.ready\' files left in the current
+	directory even after the lab has been stopped. In this case you have
+	to launch *lclean* (see *lclean*(1)) to get rid of them before
+	the lab can be restarted.
+
+_./machine_.disk
+	This is the COW filesystem for virtual machine _machine_. These
+	files are automatically removed when the lab is crashed with
+	*lcrash* (see *lcrash*(1)), so that virtual machines can revert
+	to their original state when the lab is restarted. If you want to
+	preserve .disk files, use the *-F* (or *--keep-fs*) option of
+	*lcrash*. On the other hand, *lhalt*(1) (see *lhalt*(1)) never
+	removes .disk files, unless explicitly told to do it (with the
+	*-r* or *--remove-fs* option).
+
+	See the README in the Netkit filesystem package for more information
+	about COW filesystems.
+
+_lab-path_/readyfor.test
+	This file is automatically created by *ltest* (see *ltest*(1)).
+	It is used to ensure that the status of running virtual machines is
+	only retrieved when they have all completed their boot phase.
+
+# NOTES
+
+_lstart_ is essentially a wrapper for *vstart*. Hence, if something
+goes wrong, try to investigate the parameters used in the invocation of
+*vstart* (they are reported in the _lstart_ output) and read the
+*vstart*(1) documentation.
+
+# SEE ALSO
+
+_lab.conf_(5), _lclean_(1), _lhalt_(1), _lcrash_(1), _linfo_(1),
+_ltest_(1), _make_(1), _vstart_(1), _netkit.conf_(5), Netkit filesystem
+README.
+
+# AUTHOR
+
+_lstart_ script: Stefano Pettini, Fabio Ricci, Massimo Rimondini\
+This man page: Fabio Ricci, Massimo Rimondini

--- a/core/man/man1/ltest.1.scd
+++ b/core/man/man1/ltest.1.scd
@@ -1,0 +1,280 @@
+ltest(1)
+
+# NAME
+
+ltest - test a netkit lab
+
+# SYNOPSIS
+
+*ltest* \[options\] \[_MACHINE-NAME_\...\]
+
+# DESCRIPTION
+
+_ltest_ is a tool for retrieving and saving information about the state
+of running virtual machines inside a Netkit lab. These information can
+then be distributed with the lab itself, so that users can easily test
+whether the lab still behaves in the expected way when it is being
+launched on a different machine or Netkit distribution.
+
+Basically, _ltest_ takes care of launching the lab in a \`test mode\',
+running an ad-hoc set of scripts on virtual machines, and storing their
+output on the host filesystem. If the test is being run for the first
+time, _ltest_ creates a \`\`signature\'\' of the test results that is
+used as a fingerprint of a correctly behaving lab. The next times that
+the test is run, test results are compared with the signature to check
+that the lab still behaves as expected. After running the test, the lab
+is then automatically stopped, any temporary files are deleted and the
+outcome of the test is printed as output.
+
+In the following, it is assumed that _lab-path_ is the directory in
+which the lab is located.
+
+Whenever a test is run, a subdirectory \`\_test\' is created inside
+_lab-path_ (if it does not already exist) and the results of the test
+are stored inside it. Any existing results of previous tests are
+overwritten. Subdirectory \`\_test/signature\' and \`\_test/results\'
+will contain the signature of the lab test and the outcome of the last
+executed test, respectively.
+
+Providing a list of *MACHINE-NAME*s on the command line has the effect
+of limiting the scope of the test to these virtual machines (comparing
+two tests performed on different sets of virtual machines obviously
+leads to a negative outcome).
+
+_ltest_ supports the same options as _lstart_(1), except *-f*, and
+some additional options described below.
+
+*NOTE*: Unless differently specified (e.g., by using the *--pass*
+option or environment variables), _ltest_ runs virtual machines without
+an attached terminal. Therefore, no window will pop up and no output
+will be shown by virtual machines during a test. This has been chosen in
+order to ease the automation of regression tests.
+
+# OPTIONS
+
+Besides the options supported by *lstart*, *ltest* also support the
+following options:
+
+*-R*, *--rebuild-signature*
+	Force generating a new signature for the lab, even if one already
+	exists. Overwrites any existing signature.
+
+*-S*, *--script-mode*
+	Use a more concise output with pretty printing of the test outcome,
+	which is more suitable for testing a large number of labs from a
+	script.
+
+*--verify=*_TESTTYPE_
+	After a signature has been generated, the outcome of any following
+	tests is compared with information in the signature. By default, for
+	each virtual machine _ltest_ verifies the outcome of the
+	user-defined test if one is available in the signature, or of the
+	built-in test otherwise. Option *--verify* allows to force
+	_ltest_ to always verify only a certain kind of test. Possible
+	values for _TESTTYPE_ are as follows:
+
+	*user*
+		Consider only user-defined test scripts.
+	*builtin*
+		Consider only predefined built-in tests.
+	*both*
+		Consider both kinds of test scripts (i.e., takes into account the built-in test even when a user-defined test exists for a certain virtual machine).
+
+Verifications are always performed only for those tests that exist in
+the signature, regardless of whether or not option *--verify* is
+being used.
+
+# HOW TO PERFORM A TEST
+
+A Netkit test consists of two kinds of scripts: *default* (built-in)
+and *user*.
+
+- The *default* script is built-in into the _ltest_ support scripts and cannot be changed by the user. It runs some commands inside the virtual machine in order to store the state of its network interfaces, routing table, listening TCP and UDP ports, and running processes.
+
+The output of the *default* script is saved into
+\`_lab-path_/\_test/results/_machine_.default\',
+where _machine_ is the name of the virtual machine the test has been
+performed on. The file format for the output of the default test is
+quite simple. There are several sections which are started by a textual
+description between square brackets. The contents of each section are
+the output of a specific command. The following list describes both the
+sections and the corresponding commands:
+
+*\[NETWORK INTERFACES\]*
+	(essentially) the output of \`ip addr show\'.
+
+*\[ROUTING TABLE\]*
+	(essentially) the output of \`route -n\'.
+
+*\[LISTENING PORTS\]*
+	(essentially) the output of \`netstat -tuwln\'.
+
+*\[PROCESSES\]*
+	(essentially) the output of \`ps -e -o uid,command\'.
+
+- The *user* script may be used to customize the test procedure. In particular, it can be used to dump information that are defined by a user through a personal script.
+
+_ltest_ reads the user test script for machine _machine_ from
+\`_lab-path_/\_test/_machine_.test\' and writes the output to 
+\`_lab-path_/\_test/results/_machine_.user\'. Remember that the user test 
+script must be marked as executable. You can achieve this by using the 
+following command:
+
+	chmod +x _lab-path_/\_test/_machine_.test
+
+*Notice*: every time you launch _ltest_ any existing output of
+previous tests is overwritten. Hence, remember to move output files
+elsewhere before performing other instances of the test.
+
+# RETURN VALUE
+
+_ltest_ has a zero return value if and only if the test completed
+successfully or a new signature has been generated. This allows, for
+example, to automate lab tests by using a command like the following:
+
+```
+if ! ltest -d my_lab --script-mode; then
+   echo "Lab test failed!" > lab.log
+fi
+```
+
+# FILES
+
+## Test scripts
+
+_lab-path_/\_test/_machine_.test
+	This is an executable script created by the user. Actually, it can
+	be any kind of executable file (i.e., binary files are allowed as
+	well) and, in case it is a script, it can be written in any
+	scripting language whose interpreter is installed inside virtual
+	machines.
+
+The only requirement is that it must be an executable file. To achieve
+this, you can use the following command:
+
+```
+chmod +x lab-path/_test/machine.test
+```
+
+## Test output files
+
+The output of the test scripts is stored inside the following files:
+
+_lab-path_/\_test/results/_machine_.default
+	This file contains the output of the execution of the default test
+	operations.
+
+_lab-path_/\_test/results/_machine_.user
+	This file contains the output of the execution of
+	_lab-path_/\_test/_machine_.test.
+
+## Test signature files
+
+The first time a test is being run on a lab, _ltest_ creates a
+\`\`signature\'\' instead of the test results. The signature is used by
+subsequent tests as a fingerprint of a correctly running lab. Signature
+files are exactly the same as result files, and are placed at the
+following locations:
+
+- _lab-path_/\_test/signature/_machine_.user
+- _lab-path_/\_test/results/_machine_.default
+
+## Other files
+
+_/etc/init.d/netkit-test-phase (inside virtual machines)_
+	This file is the container for the default test script. It resides
+	in the virtual machines filesystem. In case you want to alter the
+	default test operations, this is the file you must work on.
+
+	*Notice*: remember to launch a virtual machine by using the *-W*
+	option of *vstart* (see *vstart*(1)) in order to make the changes to
+	_netkit-test-phase_ permanent. Please read carefully the man page of
+	*vstart*(1) and the README in the Netkit filesystem package before
+	changing the Netkit filesystem.
+
+# EXAMPLES
+
+The following one is an example of a test file \`pc1.default\' that has
+been generated by the default testing script:
+
+```
+[INTERFACES]
+
+lo        Link encap:Local Loopback
+          inet addr:127.0.0.1  Mask:255.0.0.0
+          inet6 addr: ::1/128 Scope:Host
+          UP LOOPBACK RUNNING  MTU:16436  Metric:1
+
+
+[ROUTE]
+
+Kernel IP routing table
+Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
+
+[LISTENING PORTS]
+
+Active Internet connections (servers and established)
+Proto Recv-Q Send-Q Local Address           Foreign Address         State
+
+[PROCESSES]
+
+  UID COMMAND
+	0 init [2]
+	0 [ksoftirqd/0]
+	0 [events/0]
+	0 [khelper]
+	0 [kthread]
+	0 [kblockd/0]
+	0 [pdflush]
+	0 [pdflush]
+	0 [aio/0]
+	0 [kswapd0]
+	0 /bin/sh /etc/init.d/rc 2
+	0 /sbin/klogd
+	0 /sbin/syslogd
+	0 /bin/bash /etc/rc2.d/S99netkit-phase2 start
+	0 /bin/bash /etc/init.d/netkit-test-phase
+	0 /bin/ps -e -o uid,command
+```
+
+In order to write a customized test script you can proceed as follows.
+Assume your lab is located inside directory \`/home/foo/lab\',
+and that it consists of machines *pc1* and *pc2*. The first step to
+customize the test is to create a subdirectory \`/home/foo/lab/\_test\'.
+Once done, you can create your own test script \`/home/foo/lab/\_test/pc1.test\'
+for machine *pc1*. For example, the following script can be used to
+dump the current system time of the virtual machine by using python:
+
+```
+#!/usr/bin/python
+import time
+print time.asctime(time.localtime(time.time()));
+```
+
+It is now possible to launch the lab in test mode by using \`ltest
+/home/foo/lab\'. This will execute the default test operations (i.e.,
+dump of network interfaces, routing table, etc.) on both *pc1* and
+*pc2* and the customized script on *pc1* only. The results of the
+tests will be saved into \`/home/foo/lab/\_test/results\',
+and will consist of files \`pc1.default\', \`pc1.user\', and
+\`pc2.default\'. In particular, \`pc1.user\' should look as follows:
+
+```
+Thu Jul 21 18:31:25 2005
+```
+
+# NOTES
+
+The typical usage of this script is for regression tests of Netkit labs
+over different version of Netkit and for testing that Netkit labs work
+properly on different host configurations.
+
+# SEE ALSO
+
+_lstart_(1), _lclean_(1), _lcrash_(1), _lrestart_(1), _linfo_(1),
+_lhalt_(1).
+
+# AUTHOR
+
+ltest script: Fabio Ricci, Stefano Pettini, Massimo Rimondini\
+This man page: Fabio Ricci, Massimo Rimondini

--- a/core/man/man1/vcommand.1.scd
+++ b/core/man/man1/vcommand.1.scd
@@ -1,0 +1,72 @@
+vcommand(1)
+
+# NAME
+
+vcommand - send a command to a netkit virtual machine through its tmux session.
+
+# SYNOPSIS
+
+*vcommand* -m _MACHINE-NAME_ --timeout 10 --command ping -c1 127.0.0.1
+
+# DESCRIPTION
+
+_vcommand_ will use the tmux send-keys command to type the command into
+the tmux session for the machine. It will then wait for the time
+specified by timeout, then read any new text that has appeared in the
+tmux session, and print this.
+
+Note that there is only one shell instance in tmux, so sending multiple
+commands at once / sending commands while the tmux session is being
+actively used may result in undesirable behaviour. vcommand gives you
+access to the input and output of the machines tty, and not an instance
+of a shell to execute commands in.
+
+# OPTIONS
+
+*-h*,
+*--help*
+	Print help message and exit. Other arguments will be ignored.
+
+*-v*,
+*--verbose*
+	Set the VERBOSE variable to TRUE so it can be used for adding
+	debugging echo statements in the vcommand script.
+
+*-m* _MACHINENAME_,
+*--machine* _MACHINENAME_
+	Name of the netkit machine to send the command to.
+
+*-n* _N_
+*--timeout* _N_
+	Wait N seconds after entering the command to the tmux before
+	grabbing any new output from the tmux session.
+
+	The default value for this is 1 second.
+
+	As we don't have an interactive shell we don't know when a command has
+	finished executing. Therefore we have to choose how long we are going to
+	wait before grabbing any new output.
+
+*-c* _COMMAND_,
+*--command* _COMMAND_
+	Command to send to the tmux session. This should always be the last
+	argument given to vcommand. Anything that follows this will be taken
+	as one string and sent to the tmux session.
+
+# ENVIRONMENT VARIABLES
+
+All Netkit commands require that the *NETKIT\_HOME* variable contains
+the name of the directory Netkit is installed in.
+
+Apart from this, _vcommand_ supports no other environment variables.
+
+# SEE ALSO
+
+_vclean_(1), _vconf_(1), _vcrash_(1), _vhalt_(1), _vlist_(1),
+_vconnect_(1), _vstart_(1).
+
+# AUTHOR
+
+_vcommand_ script: Billy Bromell
+
+This man page: Billy Bromell


### PR DESCRIPTION
I have started converting the `man` pages into Markdown so that we can use [`scdoc`](https://git.sr.ht/~sircmpwn/scdoc). This will make the process of editing and maintaining `man` pages easier in the long run. Some minor changes will have to be made to the formatting during the conversion of these `man` pages but overall the quality remain the same.

```
$ man -l <(scdoc < lclean.1.scd)
```

<img src="https://user-images.githubusercontent.com/18099289/109837615-435dc480-7c3d-11eb-93ee-9223b51a9523.png" width=450px>