### PR TITLE
fix Issue #77

### DIFF
--- a/core/bin/script_utils
+++ b/core/bin/script_utils
@@ -387,7 +387,7 @@ psList() {
 # machine status. If the machine is found to exist, returned value is 0.
 # Otherwise, 1 is returned.
 getVMinfoByName() {
-   VM_PS_ENTRY=`psList | grep -w "^$1 .*umid=$2" | grep -v "grep -w" | head -n 1`
+   VM_PS_ENTRY=`psList | grep -E "^$1[[:blank:]].*umid=$2[[:space:]]" | head -n 1`
    if [ -z "$VM_PS_ENTRY" ]; then
       # Virtual machine does not exist
       return 1


### PR DESCRIPTION
This fixes the issue where machines with the name format of:
```
part1
part1<non-word-char>part2
```
causes an issue in `vcrash part1` where the `grep` through the `ps` output would return entries for both machines (since the non-word-char terminates the grep search with `-w`). The process at the top of the list would be killed, which would be the one with the lowest PID (hence could be either machine).