### PR TITLE
added ucarp support

### DIFF
--- a/fs/disabled-services
+++ b/fs/disabled-services
@@ -26,4 +26,5 @@ isc-dhcp-relay
 isc-dhcp-relay6
 systemd-timesyncd
 stunnel4
+ucarp
 xl2tpd

--- a/fs/packages-list
+++ b/fs/packages-list
@@ -85,6 +85,7 @@ tftp
 tftpd
 tshark
 traceroute
+ucarp
 vim
 vlan
 xl2tpd


### PR DESCRIPTION
Added ucarp to allow for automatic failover when a device goes down (https://manpages.ubuntu.com/manpages/bionic/man8/ucarp.8.html)