### PR TITLE
Remove ucarp from installed packages

### DIFF
--- a/fs/disabled-services
+++ b/fs/disabled-services
@@ -26,5 +26,4 @@ isc-dhcp-relay
 isc-dhcp-relay6
 systemd-timesyncd
 stunnel4
-ucarp
 xl2tpd

--- a/fs/packages-list
+++ b/fs/packages-list
@@ -85,7 +85,7 @@ tftp
 tftpd
 tshark
 traceroute
-ucarp
+# ucarp -- temporarily removed until package is added to Bullseye
 vim
 vlan
 xl2tpd


### PR DESCRIPTION
ucarp does not have a package on Debian Bullseye repositories yet. This means the package installation in [install-netkit-fs.sh](https://github.com/netkit-jh/netkit-jh-build/blob/9d3d4fe42e5fdebfa6ff0fc043e61f14fa7401ba/fs/install-netkit-fs.sh#L20) fatally fails, resulting in no packages getting installed.

This pull request can be reverted when ucarp gets added to Bullseye.