### PR TITLE
Allow tmux as a valid con0 option

### DIFF
--- a/core/bin/vstart
+++ b/core/bin/vstart
@@ -122,6 +122,8 @@ Console settings can be altered by the following options:
                           this       attach to stdin/stdout (i.e., use current
                                      terminal; only one console at a time can
                                      be set to "this" mode)
+                          tmux       run in a tmux session (only valid with
+                                     con0 - see documentation for more details)
                           pty        attach to a pseudo-terminal
                           port:xxx   attach to TCP port xxx
                           none       disable console (only valid with con1)
@@ -293,7 +295,7 @@ parseCmdLine() {
             shift; CURRENT_ARGUMENT="$1"
             checkSpaces "$CURRENT_ARGUMENT"
             case "$CURRENT_ARGUMENT" in
-               xterm|this|pty|port:*|none)   VM_CON0=$CURRENT_ARGUMENT;;
+               xterm|this|tmux|pty|port:*|none)   VM_CON0=$CURRENT_ARGUMENT;;
                *)
                   warning "$SCRIPTNAME" "$CMDLINE" "$0" \
                           "Unrecognized device for con0: $CURRENT_ARGUMENT."

--- a/core/man/man1/vstart.1
+++ b/core/man/man1/vstart.1
@@ -308,7 +308,7 @@ can still be halted by using one of the commands \fBvhalt\fR or \fBvcrash\fR.
 .TP
 .B
 tmux
-Start the VM within a tmux session.
+Start the VM within a tmux session (only valid for the primary console).
 
 .TP
 .B

--- a/core/man/man5/netkit.conf.5
+++ b/core/man/man5/netkit.conf.5
@@ -247,7 +247,7 @@ still stop it by using either \fIvhalt\fR or \fIvcrash\fR (see \fBvhalt\fR,
 .TP
 .B
 tmux
-Start the VM within a tmux session.
+Start the VM within a tmux session (only valid for the primary console).
 
 
 .PP

--- a/core/netkit.conf
+++ b/core/netkit.conf
@@ -38,6 +38,7 @@ VM_CON0=xterm                   # Virtual machine primary consoles use XTerms.
 VM_CON1=none                    # Virtual machine secondary consoles are disabled.
                                 # Allowed values for VM_CON0 and VM_CON1 are:
                                 # none, xterm, this, pty, port:port_number, tmux
+                                # Note: tmux can only be used for the primary console.
 CON0_PORTHELPER=no              # Bypass port-helper (debugging option)
 
 

--- a/core/setup_scripts/handle_config.sh
+++ b/core/setup_scripts/handle_config.sh
@@ -87,7 +87,8 @@ if [ "${CURRENT_VERSION}" -lt 5 ]; then
     echo "Upgrading Netkit configuration to V5."
 
     # Add tmux to the list of valid options for VM_CON0
-    sed -i '/^\s*\# none, xterm, this, pty, port:port_number/ s/$/, tmux/' ${NEW_DIR}/netkit.conf
+    sed -i '/^\s*\# none, xterm, this, pty, port:port_number/ s/$/, tmux\
+                                # Note: tmux can only be used for the primary console./' ${NEW_DIR}/netkit.conf
 
     # Remove USE_TMUX section as con0 is now used to handle tmux
     sed -i ':a;N;$!ba;s/USE_TMUX=FALSE.*commands to it with vcommand.//g' ${NEW_DIR}/netkit.conf


### PR DESCRIPTION
`--tmux-attached`/`--tmux-detached` allows usage of tmux alongside configuring its start-up behaviour, however there is no functionality (beyond changing `netkit.conf`) to independently set the primary console whilst using the default (`netkit.conf`) tmux start-up behaviour.

This patch adds `tmux` as a valid primary console option:
```bash
vstart test --con0=tmux
```