### PR TITLE
Fix kernel download error from commit 94fa19b115e0a3a0a0bd7f17d6b715874ef69643

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -38,7 +38,7 @@ ${BUILD_DIR}/linux-${KERNEL_VERSION}/downloaded.ready:
 	
 	# If the file exists in the cache directory, copy it to our build directory
 	# Otherwise, download it and copy it to the cache directory
-	cd ${BUILD_DIR} ; test -f ${CACHE_DIR}/${KERNEL_ARCHIVE_NAME} && cp ${CACHE_DIR}/${KERNEL_ARCHIVE_NAME} . || wget ${KERNEL_URL} --output-document=${CACHE_DIR}/${KERNEL_ARCHIVE_NAME} && cp ${KERNEL_ARCHIVE_NAME} ${CACHE_DIR}/${KERNEL_ARCHIVE_NAME}
+	cd ${BUILD_DIR} ; test -f ${CACHE_DIR}/${KERNEL_ARCHIVE_NAME} && cp ${CACHE_DIR}/${KERNEL_ARCHIVE_NAME} . || wget ${KERNEL_URL} --output-document=${CACHE_DIR}/${KERNEL_ARCHIVE_NAME} && cp ${CACHE_DIR}/${KERNEL_ARCHIVE_NAME} ${KERNEL_ARCHIVE_NAME}
 	# The file ending can be either .tar.xz (full-release) or .tar.gz (pre-release)
 	# Some tar's (GNU tar) do not require additional flags, this is therefore just a compatibility check
 	cd ${BUILD_DIR} ; test "${KERNEL_FILE_EXTENSION}" = "gz" && tar xzf ${KERNEL_ARCHIVE_NAME} || tar xJf ${KERNEL_ARCHIVE_NAME}


### PR DESCRIPTION
Building Netkit-JH from source would fail on the kernel download with `cp: cannot stat 'linux-5.13.4.tar.xz': No such file or directory`. This is because the source and destination paths of:
```bash
cp ${KERNEL_ARCHIVE_NAME} ${CACHE_DIR}/${KERNEL_ARCHIVE_NAME}
```
are the wrong around since commit 94fa19b115e0a3a0a0bd7f17d6b715874ef69643.

The `wget` outputs directly to the cache directory now, so the archive must be duplicated into the build directory (not the other way around as per the previous operation). 