### PR TITLE
Add package installer script (vpackage)

### DIFF
--- a/core/bin/script_utils
+++ b/core/bin/script_utils
@@ -39,6 +39,7 @@ export LANG=C
 : ${HUB_SOCKET_PREFIX:="vhub"}
 : ${HUB_SOCKET_EXTENSION:=".cnct"}
 : ${HUB_LOG:="$HUB_SOCKET_DIR/vhubs.log"}
+: ${VPACKAGE_MOUNT_POINT:="/mnt/netkit-fs-mount-point/"}
 : ${VM_MEMORY:=32}
 : ${VM_MEMORY_SKEW:=4}
 : ${VM_MODEL_FS:="$NETKIT_HOME/fs/netkit-fs"}

--- a/core/bin/vpackage
+++ b/core/bin/vpackage
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+
+# This script can be used to install new packages to the Netkit model
+# filesystem.
+
+
+###############################################################################
+# Write vpackage's usage line to standard output.
+# Usage:
+#   usage_line
+# Globals:
+#   r- SCRIPTNAME
+# Arguments:
+#   None
+# Returns:
+#   None
+# Example:
+#   None
+###############################################################################
+usage_line() {
+   echo "Usage: $SCRIPTNAME COMMAND [OPTION]... [PACKAGE]..."
+}
+
+
+###############################################################################
+# Write vpackage's usage as a full dialog or a "try --help".
+# Usage:
+#   usage STATUS
+# Globals:
+#   r- SCRIPTNAME
+# Arguments:
+#   $1 - status code to exit with. When zero, usage will write to standard
+#        output and describe all options (for --help). Else, it will write to
+#        standard error and be a brief usage and try-help message.
+# Returns:
+#   None - exits with a status code of STATUS
+# Example:
+#   None
+###############################################################################
+usage() {
+   local status=$1
+
+   if [ "$status" -ne 0 ]; then
+      usage_line 1>&2
+      echo 1>&2 "Try '$SCRIPTNAME --help' for more information."
+      exit "$status"
+   fi
+
+   cat << END_OF_HELP
+$(usage_line)
+Manage PACKAGEs on the model Netkit filesystem with apt-get or dpkg.
+
+The following COMMANDs operate exactly as apt-get would:
+  update              synchronise package index files with their respective
+                        sources
+  upgrade             install latest package versions
+  dist-upgrade        upgrade and potentially remove unnecessary packages
+  install PACKAGE...  install or upgrade packages and their dependencies
+  remove PACKAGE...   remove packages, leaving their configuration files
+  purge PACKAGE...    remove packages and their configuration files
+  clean               clear out the apt cache
+  autoremove          (alias auto-remove) remove dependencies that are no
+                        longer needed
+
+The following COMMANDs use other underlying package management programs:
+  list                run dpkg --list to show all installed packages on the
+                        filesystem
+
+You can use the following options to configure vpackage or the underlying
+package management command:
+  -d DIRECTORY        mount the filesystem at the directory DIRECTORY. If the
+                        mount point does not exist, Netkit will try to create
+                        it. The default is $VPACKAGE_MOUNT_POINT
+  -f, --filesystem=FILENAME  use FILENAME as the filesystem to be mounted. By
+                              default, this is $VM_MODEL_FS
+  -l, --list          show a list of running virtual machines after halting the
+                        lab
+  -o, --pass=OPTION   pass OPTION unaltered to the underlying package
+                        management command
+      --only-upgrade  only install upgrades for the selected packages. This
+                        uses the --only-upgrade option to apt-get and must be
+                        used with the install subcommand
+  -y, --assume-yes, --yes  automatic yes to prompts to run all commands
+                            non-interactively. This uses the --assume-yes
+                            underlying option and therefore will only work with
+                            apt-get (dpkg has no such option).
+
+Miscellaneous:
+      --help          display this help and exit
+  -p, --print         use the --simulate option on the underlying package
+                        management command to show which commands would be
+                        executed
+      --version       output version information and exit
+END_OF_HELP
+
+   exit "$status"
+}
+
+
+###############################################################################
+# For use with an exit trap, unmount the filesystem.
+# Usage:
+#   cleanup
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   None
+# Example:
+#   trap cleanup EXIT; ... ; exit
+###############################################################################
+cleanup() {
+   sudo umount "$mount_point"
+}
+
+
+SCRIPTNAME=$(basename "$0")
+
+if [ -z "$NETKIT_HOME" ]; then
+   echo 1>&2 "$SCRIPTNAME: The NETKIT_HOME environment variable is not set"
+   exit 1
+fi
+
+# shellcheck source=./script_utils
+. "$NETKIT_HOME/bin/script_utils"
+
+# Write to the vcommands log
+logWrite "$0 $*"
+
+
+filesystem=$VM_MODEL_FS
+mount_point=$VPACKAGE_MOUNT_POINT
+
+
+# We don't want the vpackage subcommand to be reordered by getopt, so we
+# swallow it here.
+if [ "$#" -lt 1 ]; then
+   echo 1>&2 "$SCRIPTNAME: Missing subcommand"
+   usage 1
+fi
+
+cmd=$1
+shift
+
+
+# Get command line options
+long_opts="assume-yes,filesystem:,help,only-upgrade,pass:,print,version,yes"
+short_opts="d:o:py"
+
+if ! getopt_opts=$(getopt --name "$SCRIPTNAME" --options "$short_opts" --longoptions "$long_opts" -- "$@"); then
+   # getopt will output the errorneous command-line argument
+   usage 1
+fi
+
+# (Safely) set positional parameters to those reordered by getopt
+eval set -- "$getopt_opts"
+
+while true; do
+   case $1 in
+      -d)
+         mount_point=$(readlink --canonicalize-missing "$2")
+         shift
+         ;;
+      -f|--filesystem)
+         filesystem=$(readlink --canonicalize-missing "$2")
+         shift
+         ;;
+      --help)
+         usage 0
+         ;;
+      -o|--pass)
+         passthrough_opts+=( "$2" )
+         shift
+         ;;
+      --only-upgrade)
+         if [ "$cmd" != "install" ]; then
+            echo 1>&2 "error"
+            usage 1
+         fi
+
+         passthrough_opts=( "--only-upgrade" "${passthrough_opts[@]}" )
+         ;;
+      -p|--print)
+         passthrough_opts=( "--simulate" "${passthrough_opts[@]}" )
+         ;;
+      --version)
+         showVersion
+         exit 0
+         ;;
+      -y|--assume-yes|--yes)
+         passthrough_opts=( "--assume-yes" "${passthrough_opts[@]}" )
+         ;;
+      --)
+         shift
+         break
+         ;;
+      *)
+         echo 1>&2 "$SCRIPTNAME: Unknown error parsing command line arguments"
+         usage 1
+         ;;
+   esac
+
+   shift
+done
+   
+# Non-option arguments are package names
+packages=( "$@" )
+
+
+apt_get_cmd=( "sudo" "apt-get" "$cmd" "--option" "Dir=$mount_point" "${passthrough_opts[@]}" )
+
+
+# Warn for dangerous options
+if [ "$cmd" = "dist-upgrade" ]; then
+   while true; do
+      read -rp "Warning: dist-upgrade has the potential to delete packages that may be critical to the operation of Netkit. Continue [y/N]? " response
+      case $response in
+         [Yy]|[Yy][Ee][Ss])
+            break
+            ;;
+         [Nn]|[Nn][Oo])
+            exit 0
+            ;;
+         *)
+            ;;
+      esac
+   done
+fi
+
+
+# Mount the filesystem image 
+echo "Mounting '$filesystem' to '$mount_point'"
+sudo mkdir -p "$mount_point"
+sudo mount --options loop --source "$filesystem" --target "$mount_point"
+trap cleanup EXIT
+
+
+# The following apt-get commands are not supported for reasons relating to
+# complexity or lack of necessity for most users: dselect-upgrade, source,
+# build-dep, check, autoclean|auto-clean, changelog, and indextargets.
+case $cmd in
+   list)
+      # List currently installed packages
+      dpkg-query --admindir "$mount_point/var/lib/dpkg" --list "${passthrough_opts[@]}" "${packages[@]}"
+      ;;
+   update|upgrade|dist-upgrade|clean|autoremove|auto-remove)
+      "${apt_get_cmd[@]}"
+      ;;
+   install|remove|purge)
+      "${apt_get_cmd[@]}" "${packages[@]}"
+      ;;
+   *)
+      echo 1>&2 "$SCRIPTNAME: invalid subcommand '$cmd'"
+      usage 1
+      ;;
+esac

--- a/core/bin/vpackage
+++ b/core/bin/vpackage
@@ -189,11 +189,6 @@ while true; do
          shift
          ;;
       --only-upgrade)
-         if [ "$cmd" != "install" ]; then
-            echo 1>&2 "error"
-            usage 1
-         fi
-
          passthrough_opts=( "--only-upgrade" "${passthrough_opts[@]}" )
          ;;
       -p|--print)

--- a/core/bin/vpackage
+++ b/core/bin/vpackage
@@ -140,7 +140,7 @@ mount_fs() {
    sudo mount --options loop --source "$filesystem" --target "$mount_point"
 
    echo "Bind mounting '$host_resolvconf' to '$mount_point_resolvconf'"
-   sudo mount --bind --source "$host_resolvconf" --target "$mount_point_resolvconf"
+   sudo mount --bind "$host_resolvconf" "$mount_point_resolvconf"
 
    # Enable a trap to unmount the filesystem on exit
    trap cleanup EXIT
@@ -265,7 +265,7 @@ case $subcommand in
    list)
       # List currently installed packages
       mount_fs "$filesystem" "$mount_point"
-      dpkg-query --admindir "$mount_point/var/lib/dpkg" --list "${passthrough_opts[@]}" "${packages[@]}"
+      dpkg --admindir "$mount_point/var/lib/dpkg" --list "${passthrough_opts[@]}" "${packages[@]}"
       ;;
    update|upgrade|dist-upgrade|clean|autoremove|auto-remove)
       mount_fs "$filesystem" "$mount_point"

--- a/core/bin/vpackage
+++ b/core/bin/vpackage
@@ -73,8 +73,6 @@ package management command:
                         it. The default is $VPACKAGE_MOUNT_POINT
   -f, --filesystem=FILENAME  use FILENAME as the filesystem to be mounted. By
                               default, this is $VM_MODEL_FS
-  -l, --list          show a list of running virtual machines after halting the
-                        lab
   -o, --pass=OPTION   pass OPTION unaltered to the underlying package
                         management command
       --only-upgrade  only install upgrades for the selected packages. This
@@ -112,6 +110,34 @@ END_OF_HELP
 ###############################################################################
 cleanup() {
    sudo umount "$mount_point"
+}
+
+
+###############################################################################
+# Mount a filesystem to a mount point and enable an exit trap for cleanup
+# Usage:
+#   mount_fs FILESYSTEM DIRECTORY
+# Globals:
+#   None
+# Arguments:
+#   $1 - filesystem image to mount
+#   $2 - directory to be used as the mount point (will be created if does not
+#        exist)
+# Returns:
+#   None
+# Example:
+#   None
+###############################################################################
+mount_fs() {
+   local filesystem=$1
+   local mount_point=$2
+
+   echo "Mounting '$filesystem' to '$mount_point'"
+   sudo mkdir -p "$mount_point"
+   sudo mount --options loop --source "$filesystem" --target "$mount_point"
+
+   # Enable a trap to unmount the filesystem on exit
+   trap cleanup EXIT
 }
 
 
@@ -229,29 +255,25 @@ if [ "$cmd" = "dist-upgrade" ]; then
 fi
 
 
-# Mount the filesystem image 
-echo "Mounting '$filesystem' to '$mount_point'"
-sudo mkdir -p "$mount_point"
-sudo mount --options loop --source "$filesystem" --target "$mount_point"
-trap cleanup EXIT
-
-
 # The following apt-get commands are not supported for reasons relating to
 # complexity or lack of necessity for most users: dselect-upgrade, source,
 # build-dep, check, autoclean|auto-clean, changelog, and indextargets.
 case $cmd in
    list)
       # List currently installed packages
+      mount_fs "$filesystem" "$mount_point"
       dpkg-query --admindir "$mount_point/var/lib/dpkg" --list "${passthrough_opts[@]}" "${packages[@]}"
       ;;
    update|upgrade|dist-upgrade|clean|autoremove|auto-remove)
+      mount_fs "$filesystem" "$mount_point"
       "${apt_get_cmd[@]}"
       ;;
    install|remove|purge)
+      mount_fs "$filesystem" "$mount_point"
       "${apt_get_cmd[@]}" "${packages[@]}"
       ;;
    *)
-      echo 1>&2 "$SCRIPTNAME: invalid subcommand '$cmd'"
+      echo 1>&2 "$SCRIPTNAME: Invalid subcommand '$cmd'"
       usage 1
       ;;
 esac

--- a/core/bin/vpackage
+++ b/core/bin/vpackage
@@ -163,15 +163,13 @@ mount_fs() {
    local host_resolvconf="/etc/resolv.conf"
    local mount_point_resolvconf="$mount_point/etc/resolv.conf"
 
-   echo "Mounting '$filesystem' to '$mount_point'"
    sudo mkdir -p "$mount_point"
    
    if ! sudo mount --options loop --source "$filesystem" --target "$mount_point"; then
-      echo 1>&2 "$SCRIPTNAME: Could not mount filesystem. Is it already mounted?"
+      echo 1>&2 "$SCRIPTNAME: Could not mount filesystem"
       exit 1
    fi
 
-   echo "Bind mounting '$host_resolvconf' to '$mount_point_resolvconf'"
    if ! sudo mount --bind "$host_resolvconf" "$mount_point_resolvconf"; then
       echo 1>&2 "$SCRIPTNAME: Could not bind mount name resolution file"
       sudo umount "$mount_point"

--- a/core/bin/vpackage
+++ b/core/bin/vpackage
@@ -96,20 +96,46 @@ END_OF_HELP
 
 
 ###############################################################################
+# Exit with usage 1 if string is not a valid vpackage subcommand.
+# Usage:
+#   validate_vpackage_subcommand COMMAND
+# Globals:
+#   r- SCRIPTNAME
+# Arguments:
+#   $1 - subcommand name to validate
+# Returns:
+#   None. Exits with a non-zero usage on an invalid subcommand.
+# Example:
+#   None
+###############################################################################
+validate_vpackage_subcommand() {
+   local subcommand=$1
+
+   if [[ ! "$subcommand" =~ ^(list|update|upgrade|dist-upgrade|clean|autoremove|auto-remove|install|remove|purge)$ ]]; then
+      echo 1>&2 "$SCRIPTNAME: Invalid subcommand '$subcommand'"
+      usage 1
+   fi
+}
+
+
+###############################################################################
 # For use with an exit trap, unmount the filesystem.
 # Usage:
-#   cleanup
+#   cleanup MOUNT_POINT
 # Globals:
-#   r- mount_point
-#   r- mount_point_resolvconf
-# Arguments:
 #   None
+# Arguments:
+#   $1 - directory used as the mount mount_point
 # Returns:
 #   None
 # Example:
-#   trap cleanup EXIT; ... ; exit
+#   trap "cleanup /mnt/fs" EXIT; ... ; exit
 ###############################################################################
 cleanup() {
+   local mount_point=$1
+
+   local mount_point_resolvconf="$mount_point/etc/resolv.conf"
+
    sudo umount "$mount_point_resolvconf"
    sudo umount "$mount_point"
 }
@@ -118,10 +144,9 @@ cleanup() {
 ###############################################################################
 # Mount a filesystem to a mount point and enable an exit trap for cleanup
 # Usage:
-#   mount_fs FILESYSTEM DIRECTORY
+#   mount_fs FILESYSTEM MOUNT_POINT
 # Globals:
-#   r- host_resolvconf
-#   r- mount_point_resolvconf
+#   r- SCRIPTNAME
 # Arguments:
 #   $1 - filesystem image to mount
 #   $2 - directory to be used as the mount point (will be created if does not
@@ -135,15 +160,27 @@ mount_fs() {
    local filesystem=$1
    local mount_point=$2
 
+   local host_resolvconf="/etc/resolv.conf"
+   local mount_point_resolvconf="$mount_point/etc/resolv.conf"
+
    echo "Mounting '$filesystem' to '$mount_point'"
    sudo mkdir -p "$mount_point"
-   sudo mount --options loop --source "$filesystem" --target "$mount_point"
+   
+   if ! sudo mount --options loop --source "$filesystem" --target "$mount_point"; then
+      echo 1>&2 "$SCRIPTNAME: Could not mount filesystem. Is it already mounted?"
+      exit 1
+   fi
 
    echo "Bind mounting '$host_resolvconf' to '$mount_point_resolvconf'"
-   sudo mount --bind "$host_resolvconf" "$mount_point_resolvconf"
+   if ! sudo mount --bind "$host_resolvconf" "$mount_point_resolvconf"; then
+      echo 1>&2 "$SCRIPTNAME: Could not bind mount name resolution file"
+      sudo umount "$mount_point"
+      exit 1
+   fi
 
    # Enable a trap to unmount the filesystem on exit
-   trap cleanup EXIT
+   # shellcheck disable=2064
+   trap "cleanup \"$mount_point\"" EXIT
 }
 
 
@@ -164,9 +201,6 @@ logWrite "$0 $*"
 filesystem=$VM_MODEL_FS
 mount_point=$VPACKAGE_MOUNT_POINT
 
-host_resolvconf="/etc/resolv.conf"
-mount_point_resolvconf="$mount_point/etc/resolv.conf"
-
 
 # Get command line options
 long_opts="assume-yes,filesystem:,help,only-upgrade,pass:,print,version,yes"
@@ -185,7 +219,6 @@ while true; do
       -d)
          mount_point=$(readlink --canonicalize-missing "$2")
          shift
-         mount_point_resolvconf="$mount_point/etc/resolv.conf"
          ;;
       -f|--filesystem)
          filesystem=$(readlink --canonicalize-missing "$2")
@@ -231,6 +264,8 @@ if [ "$#" -lt 1 ]; then
 fi
 
 subcommand=$1
+validate_vpackage_subcommand "$subcommand"
+
 packages=( "${@:2}" )
 
 
@@ -252,10 +287,18 @@ if [ "$subcommand" = "dist-upgrade" ]; then
 fi
 
 
+# Mount the Netkit filesystem. An EXIT trap will be set so we do not need to
+# manually unmount the filesystem at each script exit point.
+mount_fs "$filesystem" "$mount_point"
+
+
+chroot_cmd=( "sudo" "chroot" "$mount_point" )
+
+# vpackage subcommands that use apt-get can simply be passed through as a valid
+# apt-get subcommand. This is not the case with dpkg.
 # NOTE: for an unknown reason, apt-get --option RootDir does not work for
 # installing packages, rather the packages get installed to the host system.
 # chroot is not required for dpkg commands.
-chroot_cmd=( "sudo" "chroot" "$mount_point" )
 apt_get_cmd=( "${chroot_cmd[@]}" "apt-get" "${passthrough_opts[@]}" "$subcommand" )
 
 # The following apt-get commands are not supported for reasons relating to
@@ -263,20 +306,15 @@ apt_get_cmd=( "${chroot_cmd[@]}" "apt-get" "${passthrough_opts[@]}" "$subcommand
 # build-dep, check, autoclean|auto-clean, changelog, and indextargets.
 case $subcommand in
    list)
-      # List currently installed packages
-      mount_fs "$filesystem" "$mount_point"
-      dpkg --admindir "$mount_point/var/lib/dpkg" --list "${passthrough_opts[@]}" "${packages[@]}"
+      # We don't use --admindir in the event that the host system does not have
+      # the dpkg. Instead, the dpkg binary on the Netkit filesystem will be
+      # used.
+      "${chroot_cmd[@]}" dpkg --list "${passthrough_opts[@]}" "${packages[@]}"
       ;;
    update|upgrade|dist-upgrade|clean|autoremove|auto-remove)
-      mount_fs "$filesystem" "$mount_point"
       "${apt_get_cmd[@]}"
       ;;
    install|remove|purge)
-      mount_fs "$filesystem" "$mount_point"
       "${apt_get_cmd[@]}" "${packages[@]}"
-      ;;
-   *)
-      echo 1>&2 "$SCRIPTNAME: Invalid subcommand '$subcommand'"
-      usage 1
       ;;
 esac

--- a/core/bin/vpackage
+++ b/core/bin/vpackage
@@ -159,17 +159,6 @@ filesystem=$VM_MODEL_FS
 mount_point=$VPACKAGE_MOUNT_POINT
 
 
-# We don't want the vpackage subcommand to be reordered by getopt, so we
-# swallow it here.
-if [ "$#" -lt 1 ]; then
-   echo 1>&2 "$SCRIPTNAME: Missing subcommand"
-   usage 1
-fi
-
-cmd=$1
-shift
-
-
 # Get command line options
 long_opts="assume-yes,filesystem:,help,only-upgrade,pass:,print,version,yes"
 short_opts="d:o:py"
@@ -230,15 +219,18 @@ while true; do
    shift
 done
    
-# Non-option arguments are package names
-packages=( "$@" )
+# The first non-option argument is the subcommand, the rest are package names
+if [ "$#" -lt 1 ]; then
+   echo 1>&2 "$SCRIPTNAME: Missing subcommand"
+   usage 1
+fi
 
-
-apt_get_cmd=( "sudo" "apt-get" "$cmd" "--option" "Dir=$mount_point" "${passthrough_opts[@]}" )
+subcommand=$1
+packages=( "${@:2}" )
 
 
 # Warn for dangerous options
-if [ "$cmd" = "dist-upgrade" ]; then
+if [ "$subcommand" = "dist-upgrade" ]; then
    while true; do
       read -rp "Warning: dist-upgrade has the potential to delete packages that may be critical to the operation of Netkit. Continue [y/N]? " response
       case $response in
@@ -255,10 +247,12 @@ if [ "$cmd" = "dist-upgrade" ]; then
 fi
 
 
+apt_get_cmd=( "sudo" "apt-get" "$subcommand" "--option" "Dir=$mount_point" "${passthrough_opts[@]}" )
+
 # The following apt-get commands are not supported for reasons relating to
 # complexity or lack of necessity for most users: dselect-upgrade, source,
 # build-dep, check, autoclean|auto-clean, changelog, and indextargets.
-case $cmd in
+case $subcommand in
    list)
       # List currently installed packages
       mount_fs "$filesystem" "$mount_point"
@@ -273,7 +267,7 @@ case $cmd in
       "${apt_get_cmd[@]}" "${packages[@]}"
       ;;
    *)
-      echo 1>&2 "$SCRIPTNAME: Invalid subcommand '$cmd'"
+      echo 1>&2 "$SCRIPTNAME: Invalid subcommand '$subcommand'"
       usage 1
       ;;
 esac

--- a/core/bin/vpackage
+++ b/core/bin/vpackage
@@ -100,7 +100,8 @@ END_OF_HELP
 # Usage:
 #   cleanup
 # Globals:
-#   None
+#   r- mount_point
+#   r- mount_point_resolvconf
 # Arguments:
 #   None
 # Returns:
@@ -109,6 +110,7 @@ END_OF_HELP
 #   trap cleanup EXIT; ... ; exit
 ###############################################################################
 cleanup() {
+   sudo umount "$mount_point_resolvconf"
    sudo umount "$mount_point"
 }
 
@@ -118,7 +120,8 @@ cleanup() {
 # Usage:
 #   mount_fs FILESYSTEM DIRECTORY
 # Globals:
-#   None
+#   r- host_resolvconf
+#   r- mount_point_resolvconf
 # Arguments:
 #   $1 - filesystem image to mount
 #   $2 - directory to be used as the mount point (will be created if does not
@@ -135,6 +138,9 @@ mount_fs() {
    echo "Mounting '$filesystem' to '$mount_point'"
    sudo mkdir -p "$mount_point"
    sudo mount --options loop --source "$filesystem" --target "$mount_point"
+
+   echo "Bind mounting '$host_resolvconf' to '$mount_point_resolvconf'"
+   sudo mount --bind --source "$host_resolvconf" --target "$mount_point_resolvconf"
 
    # Enable a trap to unmount the filesystem on exit
    trap cleanup EXIT
@@ -158,6 +164,9 @@ logWrite "$0 $*"
 filesystem=$VM_MODEL_FS
 mount_point=$VPACKAGE_MOUNT_POINT
 
+host_resolvconf="/etc/resolv.conf"
+mount_point_resolvconf="$mount_point/etc/resolv.conf"
+
 
 # Get command line options
 long_opts="assume-yes,filesystem:,help,only-upgrade,pass:,print,version,yes"
@@ -176,6 +185,7 @@ while true; do
       -d)
          mount_point=$(readlink --canonicalize-missing "$2")
          shift
+         mount_point_resolvconf="$mount_point/etc/resolv.conf"
          ;;
       -f|--filesystem)
          filesystem=$(readlink --canonicalize-missing "$2")
@@ -242,7 +252,11 @@ if [ "$subcommand" = "dist-upgrade" ]; then
 fi
 
 
-apt_get_cmd=( "sudo" "apt-get" "$subcommand" "--option" "Dir=$mount_point" "${passthrough_opts[@]}" )
+# NOTE: for an unknown reason, apt-get --option RootDir does not work for
+# installing packages, rather the packages get installed to the host system.
+# chroot is not required for dpkg commands.
+chroot_cmd=( "sudo" "chroot" "$mount_point" )
+apt_get_cmd=( "${chroot_cmd[@]}" "apt-get" "${passthrough_opts[@]}" "$subcommand" )
 
 # The following apt-get commands are not supported for reasons relating to
 # complexity or lack of necessity for most users: dselect-upgrade, source,

--- a/core/man/man1/vpackage.1
+++ b/core/man/man1/vpackage.1
@@ -1,0 +1,89 @@
+.TH VPACKAGE 1 "October 2021" "" "Netkit"
+.SH NAME
+vpackage \- manage packages on the Netkit model filesystem
+.SH SYNOPSIS
+.B vpackage
+\fI\,COMMAND\/\fR [\fI\,OPTION\/\fR]... [\fI\,PACKAGE\/\fR]...
+.SH DESCRIPTION
+.PP
+Manage PACKAGEs on the model Netkit filesystem with apt-get or dpkg.
+.PP
+Unless the \fB\-\-help\fR option is given, one of the commands below must be
+present. The following COMMANDs operate exactly as apt-get would:
+.TP
+\fBupdate\fR
+synchronise package index files with their respective sources
+.TP
+\fBupgrade\fR
+install latest package versions
+.TP
+\fBdist-upgrade\fR
+upgrade and potentially remove unnecessary packages
+.TP
+\fBinstall\fR \fRPACKAGE\fR...
+install or upgrade packages and their dependencies
+.TP
+\fBremove\fR \fIPACKAGE\fR...
+remove packages, leaving their configuration files
+.TP
+\fBpurge\fR \fIPACKAGE\fR...
+remove packages and their configuration files
+.TP
+\fBclean\fR
+clear out the apt cache
+.TP
+\fBautoremove\fR (alias \fBauto-remove\fR)
+remove dependencies that are no longer needed
+.PP
+You can use the following options to configure \fIvpackage\fR or the underlying
+package management command:
+.TP
+\fB\-d\fR \fI\,DIRECTORY\/\fR
+mount the filesystem at the directory DIRECTORY. If the mount point does not
+exist, Netkit will try to create it. The default is $VPACKAGE_MOUNT_POINT
+.TP
+\fB\-f\fR, \fB\-\-filesystem\fR=\fI\,FILENAME\/\fR
+use \fIFILENAME\fR as the filesystem to be mounted. By default, this is $VM_MODEL_FS
+.TP
+\fB\-o\fR, \fB\-\-pass=\fI\,OPTION\/\fR
+pass \fIOPTION\fR unaltered to the underlying package management command
+.TP
+\fB\-\-only\-upgrade
+only install upgrades for the selected packages. This uses the \fB\-\-only\-upgrade\fR
+option to apt\-get and must be used with the \fBinstall\fR subcommand
+.TP
+\fB\-y\fR, \fB\-\-assume\-yes\fR, \fB\-\-yes\fR
+automatic yes to prompts to run all commands non\-interactively. This uses the
+\fB\-\-assume\-yes\fR underlying option and therefore will only work with
+apt\-get (dpkg has no such option)
+.PP
+Miscellaneous
+.TP
+\fB\-\-help\fR
+display this help and exit
+.TP
+\fB\-p\fR, \fB\-\-print\fR
+use the \fB\-\-simulate\fR option on the underlying package management command
+to show which commands would be executed
+.TP
+\fB\-\-version\fR
+output version information and exit
+
+.SH "SEE ALSO"
+\fIvclean\fR(1),
+\fIvcommand\fR(1),
+\fIvconf\fR(1),
+\fIvconnnect\fR(1),
+\fIvcrash\fR(1),
+\fIvdump\fR(1),
+\fIvhalt\fR(1),
+\fIvlist\fR(1),
+\fIvstart\fR(1),
+Netkit filesystem README.
+
+.SH AUTHOR
+\fIvpackage\fR script: Adam Bromiley
+.br
+This man page: Adam Bromiley
+
+.so include/bugreport.man

--- a/core/netkit.conf
+++ b/core/netkit.conf
@@ -5,7 +5,7 @@
 
 # Warning: none of the following parameters can include spaces in its value.
 
-CONFIG_VERSION=4
+CONFIG_VERSION=6
 
 # Command log file name (use a null file name to disable logging)
 #LOGFILENAME="$NETKIT_HOME/netkit_commands.log"
@@ -23,6 +23,9 @@ HUB_LOG="$HUB_SOCKET_DIR/vhubs.log"
 
 # Use sudo instead of su
 USE_SUDO=yes
+
+# Default mount directory used by vpackage
+VPACKAGE_MOUNT_POINT="/mnt/netkit-fs-mount-point/"
 
 
 # Virtual machines defaults

--- a/core/setup_scripts/handle_config.sh
+++ b/core/setup_scripts/handle_config.sh
@@ -82,7 +82,6 @@ if [ "${CURRENT_VERSION}" -lt 4 ]; then
 fi
 
 # Upgrade from v4 to v5
-# - Sets mconsole dir to machines again due to broken V3 configuration
 if [ "${CURRENT_VERSION}" -lt 5 ]; then
     echo "Upgrading Netkit configuration to V5."
 
@@ -100,6 +99,20 @@ if [ "${CURRENT_VERSION}" -lt 5 ]; then
     sed -i 's/# This option only takes effect when USE_TMUX is true/# This option only takes effect when VM_CON0=tmux/g' ${NEW_DIR}/netkit.conf
 	
     # Finally, update the version.
-    CURRENT_VERSION=4
-    sed -i "s/CONFIG_VERSION=3/CONFIG_VERSION=4/g" ${NEW_DIR}/netkit.conf
+    CURRENT_VERSION=5
+    sed -i "s/CONFIG_VERSION=4/CONFIG_VERSION=5/g" ${NEW_DIR}/netkit.conf
+fi
+
+# Upgrade from v5 to v6
+if [ "${CURRENT_VERSION}" -lt 6 ]; then
+    echo "Upgrading Netkit configuration to V6."
+
+    echo "
+# Default mount directory used by vpackage
+VPACKAGE_MOUNT_POINT=\"/mnt/netkit-fs-mount-point/\"
+    " >> ${NEW_DIR}/netkit.conf
+
+    # Finally, update the version.
+    CURRENT_VERSION=6
+    sed -i "s/CONFIG_VERSION=5/CONFIG_VERSION=6/g" ${NEW_DIR}/netkit.conf
 fi


### PR DESCRIPTION
This PR adds a vcommand called `vpackage`.

The script mounts the Netkit filesystem image to `/mnt/netkit-fs-mount-point` (default), `chroot`s into the mount point, and then performs a package management command on the filesystem before unmounting it.

Supported subcommands that are passed directly into `apt-get` are:
```
  update              synchronise package index files with their respective
                        sources
  upgrade             install latest package versions
  dist-upgrade        upgrade and potentially remove unnecessary packages
  install PACKAGE...  install or upgrade packages and their dependencies
  remove PACKAGE...   remove packages, leaving their configuration files
  purge PACKAGE...    remove packages and their configuration files
  clean               clear out the apt cache
  autoremove          (alias auto-remove) remove dependencies that are no
                        longer needed
```
and `list` is a subcommand that triggers `dpkg --list`.

Some Apt subcommands were not implemented for reasons relating to lack of usefulness in a mounted filesystem or the fact they added unnecessary complexity to the script.

Some Apt options are provided in the `vpackage` command line, and additional ones may be specified with the `--pass` passthrough option.

The pull request also adds the `VPACKAGE_MOUNT_POINT` variable to `netkit.conf` to specify the default mount point for the filesystem. The config version was also bumped straight from 4 to 6 to fix an earlier issue where the version was not increased to 5 after an update.

TODO: currently it is assumed that the host system has a valid `/etc/resolv.conf` file specifying a nameserver. This is bind mounted into the filesystem mountpoint at `$MOUNT_DIRECTORY/etc/resolv.conf`. In the event that the user does not have such a file, there should be a `--nameserver=ADDR` option to specify nameserver. The original plan was generating a temporary file containing `nameserver ADDR` and bind mounting that in - this did not work for an unknown reason.