### PR TITLE
Add libstrongswan-extra-plugins

### DIFF
--- a/fs/packages-list
+++ b/fs/packages-list
@@ -53,6 +53,7 @@ openssh-client
 openssh-server
 openssl
 strongswan
+libstrongswan-extra-plugins
 openvpn
 # cpdns-recursor
 ppp


### PR DESCRIPTION
StrongSwan needs a HTTP fetcher plugin (`curl` or `soup`) to do OCSP requests. Neither are provided by default but `libstrongswan-extra-plugins` provides `curl`.