### PR TITLE
Use portable `awk` options

### DIFF
--- a/core/bash-completion/helpers
+++ b/core/bash-completion/helpers
@@ -34,7 +34,7 @@ _get_cmd_opts() {
    # Get long options
    "$NETKIT_HOME/bin/$cmd" --help |
       grep --extended-regexp --only-matching "^(  -[[:alnum:]], | {6})--[[:alnum:]-]+=?" |
-      awk --field-separator "," '{ gsub(/[[:blank:]]/, "", $NF); print $NF }'
+      awk -F "," '{ gsub(/[[:blank:]]/, "", $NF); print $NF }'
 
    # Get short options
    # NOTE: we don't gather the short options because conventionally linux

--- a/core/bin/vcommon
+++ b/core/bin/vcommon
@@ -643,9 +643,9 @@ invoke_uml_switch() {
    hub_log_cmd=(
       "stdbuf" "--output=0" "--"
       "awk"
-         "--assign" "HUB=$socket"
-         "--assign" "USER=$USER_ID"
-         "--assign" "TIME=$(date --iso-8601=seconds)"
+         "-v" "HUB=$socket"
+         "-v" "USER=$USER_ID"
+         "-v" "TIME=$(date --iso-8601=seconds)"
          '{printf "%s %15s %25s %s\n", TIME, USER, HUB, $0}'
    )
 


### PR DESCRIPTION
Patch for version 2.0.0-beta.

Current commands use longopts over shortopts for readability. As identified by @Oshawk, this presents an issue with `awk` where GNU awk is not commonly installed by default (mawk is used by default in Ubuntu). Using shortopts (`-v` and `-F`) is a more portable alternative.