### PR TITLE
Unset global file variable after usage in .bashrc

### DIFF
--- a/install-netkit-jh.sh
+++ b/install-netkit-jh.sh
@@ -297,6 +297,8 @@ for rc_file in "${rc_files[@]}"; do
 for file in "$NETKIT_HOME/bash-completion/completions/"*; do
    . "$file"
 done
+
+unset file
 EOF
    fi
 


### PR DESCRIPTION
Unset the `file` variable used to load completion scripts in `.bashrc`. Without this, every shell session will have a global `file` variable set to the vstart completion script path.