### PR TITLE
Create install directory if old install was backed up

### DIFF
--- a/install-netkit-jh.sh
+++ b/install-netkit-jh.sh
@@ -198,9 +198,10 @@ if [ -d "$install_dir/" ]; then
    echo "$install_dir: Directory exists; renaming to $backup_dir so contents are not disturbed"
    mv -- "$install_dir/" "$backup_dir/"
 else
-   mkdir --parents -- "$install_dir"
    unset backup_dir
 fi
+
+mkdir --parents -- "$install_dir"
 
 
 # Check whether they've specified extracted files


### PR DESCRIPTION
When an old install is backed up, the target directory for the current install is not created.

This patch fixes that by creating the install directory regardless of an old install existing or not.