### PR TITLE
Kill tmux sessions with `vclean`

### DIFF
--- a/core/bash-completion/completions/vconnect
+++ b/core/bash-completion/completions/vconnect
@@ -77,7 +77,8 @@ _vconnect() {
          # argument.
          #
          # Covered options:
-         # --help, -l, --list, -t, --terminal, --version
+         # --help, -k, --kill, --kill-all, -l, --list, -t, --terminal,
+         # --version
          case $current_word in
             -*)
                # Current word is a new option

--- a/core/bin/block-wrapper
+++ b/core/bin/block-wrapper
@@ -61,37 +61,15 @@ wt_safe_bash_cmd=( "bash" "-c" "$pid_cmd\\; ${kernel_cmd[*]@Q}" )
 
 
 case $term in
-   alacritty)  alacritty                                                  --command "${bash_cmd[@]}";;
-   gnome)      gnome-terminal --title "$vhost"                            --        "${bash_cmd[@]}";;
-   kitty)      kitty --title "$vhost"                                               "${bash_cmd[@]}";;
-   kitty-tab)  "$NETKIT_HOME/bin/kitty-tab.sh"                                      "${bash_cmd[@]}";;
-   konsole)    konsole --nofork --title "$vhost"                          -e        "${bash_cmd[@]}";;
-   wsl)        cmd.exe /c start wsl.exe                                             "${bash_cmd[@]}";;
-   wt)         wt.exe --suppressApplicationTitle --title "$vhost" wsl.exe --exec    "${wt_safe_bash_cmd[@]}";;
-   xterm)      xterm -xrm 'XTerm*allowTitleOps: false' -T "$vhost"        -e        "${bash_cmd[@]}";;
-   tmux)
-      # Check if tmux session already exists
-      if tmux -L netkit has-session -t "$vhost" > /dev/null 2>&1; then
-         while true; do
-            read -rp "tmux session already exists for machine $vhost. Kill session [y/N]? " response
-            case $response in
-               [Yy]|[Yy][Ee][Ss])
-                  # Kill existing tmux session
-                  tmux -L netkit kill-session -t "$vhost"
-                  break
-                  ;;
-               ""|[Nn]|[Nn][Oo])
-                  echo "tmux session in use - not starting $vhost."
-                  exit
-                  ;;
-            esac
-         done
-      fi
-
-      # Start detached tmux session
-      tmux -L netkit -f "$NETKIT_HOME/tools/tmux.conf" new-session -d -s "$vhost" "${bash_cmd[@]}"
-      ;;
-
+   alacritty)  alacritty --command                                                         "${bash_cmd[@]}";;
+   gnome)      gnome-terminal --title "$vhost" --                                          "${bash_cmd[@]}";;
+   kitty)      kitty --title "$vhost"                                                      "${bash_cmd[@]}";;
+   kitty-tab)  "$NETKIT_HOME/bin/kitty-tab.sh"                                             "${bash_cmd[@]}";;
+   konsole)    konsole --nofork --title "$vhost" -e                                        "${bash_cmd[@]}";;
+   wsl)        cmd.exe /c start wsl.exe                                                    "${bash_cmd[@]}";;
+   wt)         wt.exe --suppressApplicationTitle --title "$vhost" wsl.exe --exec           "${wt_safe_bash_cmd[@]}";;
+   xterm)      xterm -xrm 'XTerm*allowTitleOps: false' -T "$vhost" -e                      "${bash_cmd[@]}";;
+   tmux)       tmux -L netkit -f "$NETKIT_HOME/tools/tmux.conf" new-session -d -s "$vhost" "${bash_cmd[@]}";;
    *)
       echo "Terminal $term not supported, defaulting to xterm."
       xterm -xrm 'XTerm*allowTitleOps: false' -T "$vhost" -e "${bash_cmd[@]}"

--- a/core/bin/lstart
+++ b/core/bin/lstart
@@ -80,10 +80,10 @@ END_OF_HELP
    fi
 
    cat << END_OF_HELP
-  --tmux-attached     run each VM in tmux and start a terminal attached to the
+      --tmux-attached  run each VM in tmux and start a terminal attached to the
                         tmux session. This is the same as VM_CON0=tmux and
                         TMUX_OPEN_TERMS=yes in netkit.conf
-  --tmux-detached     run each VM in a tmux session without opening terminals.
+      --tmux-detached  run each VM in a tmux session without opening terminals.
                         This is the same as VM_CON0=tmux and TMUX_OPEN_TERMS=no
                         in netkit.conf
   -l, --list          show a list of running virtual machines after starting up

--- a/core/bin/vclean
+++ b/core/bin/vclean
@@ -79,7 +79,8 @@ By default, the script just removes unused virtual hubs.
   -K, --kill-machines  Kill all running virtual machines and virtual hubs. This
                         corresponds to crashing all running virtual machines
                         (even those that are frozen) and the virtual hubs they
-                        are attached to.
+                        are attached to. The 'netkit' tmux server will be
+                        killed for the current user.
   -T, --remove-tunnels  Remove tunnels and other configuration settings that
                          have been altered in order to set up "tap" interfaces.
                          If the user specified is not '-' (all), current
@@ -152,6 +153,40 @@ kill_hubs() {
    done
 
    [ -z "$found_unused_hub" ] && echo "No unused virtual hubs have been found."
+}
+
+
+###############################################################################
+# Kill all open tmux sessions.
+# Usage:
+#   kill_all_tmux_sessions TEST_MODE USER
+# Arguments:
+#   $1 - set to 1 for test mode, empty string otherwise
+#   $2 - owner of the machines; pass an empty string for all users
+# Returns:
+#   None.
+###############################################################################
+kill_all_tmux_sessions() {
+   local test_mode=$1
+   local target_user=$2
+
+   # We can only manage tmux sessions owned by the current user
+   if [ -z "$target_user" ]; then
+      warn "Can only kill tmux sessions owned by $USER_ID (the current user)"
+   elif [ "$target_user" != "$USER_ID" ]; then
+      warn "Cannot kill tmux sessions owned by another user"
+      return
+   fi
+
+   echo -n "tmux server 'netkit'"
+
+   if [ -z "$test_mode" ]; then
+      echo -n ": Killing... "
+      tmux -L netkit kill-server 2> /dev/null
+      echo -n "done."
+   fi
+
+   echo ""
 }
 
 
@@ -386,6 +421,10 @@ if [ -n "$kill_machines" ]; then
 
    # Force kill all uml_switch processes and clean up their hub files
    kill_hubs "1" "$test_mode" "${hub_pids[@]}"
+
+   # Kill the 'netkit' tmux server
+   echo "Killing Netkit tmux sessions owned by $user_str:"
+   kill_all_tmux_sessions "$test_mode" "$target_user"
 fi
 
 

--- a/core/bin/vconnect
+++ b/core/bin/vconnect
@@ -26,7 +26,7 @@
 #   usage_line
 ###############################################################################
 usage_line() {
-   echo "Usage: $SCRIPTNAME [OPTION]... MACHINE"
+   echo "Usage: $SCRIPTNAME [OPTION]... MACHINE..."
 }
 
 
@@ -52,7 +52,7 @@ usage() {
 
    cat << END_OF_HELP
 $(usage_line)
-Connect to the tmux session of a Netkit MACHINE.
+Connect to the tmux session of a Netkit MACHINE or terminate existing ones.
 
   -l, --list          list all running sessions on the tmux 'netkit' server
   -k, --kill          kill the MACHINE's already-running tmux session (if

--- a/core/bin/vconnect
+++ b/core/bin/vconnect
@@ -55,6 +55,12 @@ $(usage_line)
 Connect to the tmux session of a Netkit MACHINE.
 
   -l, --list          list all running sessions on the tmux 'netkit' server
+  -k, --kill          kill the MACHINE's already-running tmux session (if
+                        exists)
+      --kill-all      kill all running tmux sessions on the 'netkit' server
+
+
+The following options control how the tmux session is connected to:
   -t, --terminal      connect to the tmux session from a new terminal. The
                         terminal opened is dependent on the TERM_TYPE set in
                         netkit.conf
@@ -137,8 +143,8 @@ unset TMUX
 
 
 # Get command line options
-long_opts="help,interval:,list,retry-count:,terminal,version"
-short_opts="lm:n:r:t"
+long_opts="help,interval:,kill,kill-all,list,retry-count:,terminal,version"
+short_opts="klm:n:r:t"
 
 if ! getopt_opts=$(getopt --name "$SCRIPTNAME" --options "$short_opts" --longoptions "$long_opts" -- "$@"); then
    # getopt will output the errorneous command-line argument
@@ -152,6 +158,12 @@ while true; do
    case $1 in
       --help)
          usage 0
+         ;;
+      -k|--kill)
+         kill=1
+         ;;
+      --kill-all)
+         kill_all=1
          ;;
       -l|--list)
          list_only=1
@@ -191,18 +203,51 @@ if [ -n "$list_only" ]; then
    exit 0
 fi
 
+if [ -n "$kill_all" ]; then
+   tmux -L netkit kill-server
+   exit 0
+fi
+
 
 # Parse virtual machine name
 if [ $# -eq 0 ]; then
    warn "Missing machine name"
    usage 1
-elif [ $# -gt 1 ]; then
+fi
+
+vhosts=( "$@" )
+validate_hostnames "${vhosts[@]}"
+
+
+if [ -n "$kill" ]; then
+   for vhost in "${vhosts[@]}"; do
+      unset killed
+
+      if tmux -L netkit has-session -t "$vhost" 2>/dev/null; then
+         echo "Killing tmux session '$vhost'"
+         tmux -L netkit kill-session -t "$vhost"
+         killed=1
+      fi
+
+      if tmux -L netkit has-session -t "$vhost-dead" 2>/dev/null; then
+         echo "Killing tmux session '$vhost-dead'"
+         tmux -L netkit kill-session -t "$vhost-dead"
+         killed=1
+      fi
+
+      [ -z "$killed" ] && warn "No tmux sessions from '$vhost' to kill"
+   done
+
+   exit 0
+fi
+
+
+if [ "${#vhosts[@]}" -gt 1 ]; then
    warn "Can only specify one machine"
    usage 1
 fi
 
-vhost=$1
-validate_hostnames "$vhost"
+vhost=${vhosts[0]}
 
 
 echo -n "Connecting to '$vhost'."

--- a/core/bin/vstart
+++ b/core/bin/vstart
@@ -796,6 +796,14 @@ if [ -z "$just_print" ]; then
       warn "Filesystem '$fs' is already in use; specify a different filesystem"
       exit 1
    fi
+
+   if [ "$VM_CON0" = "tmux" ]; then
+      # Check if tmux session already exists
+      if tmux -L netkit has-session -t "$vhost" > /dev/null 2>&1; then
+         warn "tmux session already exists for machine '$vhost'"
+         exit 1
+      fi
+   fi
 fi
 
 

--- a/core/bin/vstart
+++ b/core/bin/vstart
@@ -800,7 +800,7 @@ if [ -z "$just_print" ]; then
    if [ "$VM_CON0" = "tmux" ]; then
       # Check if tmux session already exists
       if tmux -L netkit has-session -t "$vhost" > /dev/null 2>&1; then
-         warn "tmux session already exists for machine '$vhost'"
+         warn "tmux session already exists for machine '$vhost'; kill with 'vconnect -k'"
          exit 1
       fi
    fi

--- a/core/man/man1/vconnect.1
+++ b/core/man/man1/vconnect.1
@@ -26,6 +26,20 @@ Print help message and exit. Other arguments will be ignored.
 
 .TP
 .B
+-k
+.PD 0
+.TP
+.B
+--kill
+Kill the machine's already-running tmux session (if exists).
+
+.TP
+.B
+--kill-all
+Kill all running tmux sessions on the 'netkit' server.
+
+.TP
+.B
 -l
 .PD 0
 .TP
@@ -60,9 +74,9 @@ Name of the netkit machine to connect to.
 --retry-count \fIN\fR
 If the first attempt to connect to the tmux session fails,
 retry N times.
+
 .TP
 .B
-
 -n \fIX\fR
 .PD 0
 .TP


### PR DESCRIPTION
`vclean --kill-machines` now kills the 'netkit' tmux server. This is only possible for the server owned by the current user so a warning has been added where appropriate (using `su` to get around this would cause inconsistency with other Netkit commands that perform operations on behalf of other users).

`vconnect` now has a `-k`/`--kill` and `--kill-all` option for terminating tmux sessions per-machine.

If a tmux session for a machine already exists, `vstart` will now fail (behaviour in accordance with other conflicts). The original method of prompting the user for permission to kill the session did not work when `vstart` was ran in the background (i.e., when used with `lstart`).

The lack of Bash completion for lstart/ltest's `--tmux-attached`/`--tmux-detached` options has also been fixed.