### PR TITLE
Ignore log files when cleaning labs

### DIFF
--- a/core/bin/lcommon
+++ b/core/bin/lcommon
@@ -196,7 +196,7 @@ lab_clean() {
       rm ${verbose:+"--verbose"} --force --recursive -- "${MCONSOLE_DIR:?}/$vhost"
 
       # Remove files from the lab directory
-      rm ${verbose:+"--verbose"} --force -- "$lab_dir/$vhost."{"ready","disk","log","testdone"}
+      rm ${verbose:+"--verbose"} --force -- "$lab_dir/$vhost."{"disk","ready","testdone"}
    done
 
    rm ${verbose:+"--verbose"} --force -- "$lab_dir/readyfor.test"


### PR DESCRIPTION
.log files are not created in the lab directories, they were an artefact of the original Netkit project. It is redundant to try and remove them when cleaning labs.