### PR TITLE
Change vcrash to delete fs by default (fix issue #109)

### DIFF
--- a/core/bash-completion/completions/vcrash
+++ b/core/bash-completion/completions/vcrash
@@ -76,7 +76,7 @@ _vcrash() {
          # argument.
          #
          # Covered options:
-         # --help, --just-kill, -k, -q, --quick, -r, --remove-fs, --test, -v,
+         # -F, --help, --just-kill, -k, --keep-fs, -q, --quick, --test, -v,
          # --verbose, --version
          case $current_word in
             -*)

--- a/core/bin/lcommon
+++ b/core/bin/lcommon
@@ -231,7 +231,7 @@ lab_crash() {
    vcrash_args+=(
       ${verbose:+"--verbose"}
       ${quick_mode:+"--quick"}
-      ${keep_fs:-"--remove-fs"}
+      ${keep_fs:+"--keep-fs"}
       ${just_kill:+"--just-kill"}
    )
 

--- a/core/bin/vcrash
+++ b/core/bin/vcrash
@@ -60,8 +60,16 @@ usage() {
    cat << END_OF_HELP
 $(usage_line)
 Kill running virtual machines without halting them. This roughly corresponds to
-disconnecting their power plug.
+disconnecting their power plug. This is very fast but at the same time may
+cause filesystem inconsistencies inside virtual machines. By default,
+filesystems are removed.
 
+  -F, --keep-fs       avoid deleting virtual machines filesystems. This is
+                        useful when virtual machines are to be restarted while
+                        preserving filesystem contents. By default, all the
+                        filesystems are deleted after crashing the
+                        corresponding virtual machine. Notice that, regardless
+                        of this option, the model filesystem is never deleted
   -k, --just-kill     by default, virtual machines are crashed by using their
                         mconsole socket. This method is generally faster, but
                         in some situations it may not work properly (for
@@ -78,10 +86,6 @@ disconnecting their power plug.
                         when mconsole is being used (default behaviour unless
                         -k is used). Of course, a check inside vcrash prevents
                         from waiting endlessly
-  -r, --remove-fs     delete virtual machine (COW) filesystem after crashing
-                        machine. Using this option has no effect on machines
-                        started with the --no-cow option. Log files are not
-                        removed
       --test          do not actually crash virtual machines. Just show which
                         processes would be killed or which mconsole socket
                         would be used to send the crash directive
@@ -280,8 +284,8 @@ target_user=$USER_ID
 
 
 # Get command line options
-long_opts="help,just-kill,quick,remove-fs,root,test,user:,verbose,version"
-short_opts="kqru:v"
+long_opts="help,just-kill,keep-fs,quick,test,user:,verbose,version"
+short_opts="Fkqu:v"
 
 if ! getopt_opts=$(getopt --name "$SCRIPTNAME" --options "$short_opts" --longoptions "$long_opts" -- "$@"); then
    # getopt will output the errorneous command-line argument
@@ -293,6 +297,9 @@ eval set -- "$getopt_opts"
 
 while true; do
    case $1 in
+      -F|--keep-fs)
+         keep_fs=1
+         ;;
       --help)
          usage 0
          ;;
@@ -301,9 +308,6 @@ while true; do
          ;;
       -q|--quick)
          quick_mode=1
-         ;;
-      -r|--remove-fs)
-         rm_fs=1
          ;;
       --test)
          test_mode=1
@@ -379,8 +383,8 @@ for vhost in "${vhosts[@]}"; do
          tmux -L netkit kill-session -t "$vhost-dead"
       fi
 
-      # Remove filesystem (.disk file)
-      [ -n "$rm_fs" ] && [ -n "${vhost_info[disk]}" ] &&
+      # Remove filesystem (.disk file) by default
+      [ -z "$keep_fs" ] && [ -n "${vhost_info[disk]}" ] &&
          rm --force --verbose -- "${vhost_info[disk]}"
    fi
 done

--- a/core/man/man1/lcrash.1
+++ b/core/man/man1/lcrash.1
@@ -16,6 +16,7 @@ may result in a dirty shutdown where integrity of the virtual machines'
 filesystems
 .RI ( .disk " files)"
 cannot be guaranteed.
+Therefore, by default, filesystems are removed.
 First, the UML management console client,
 .BR uml_mconsole ,
 is used to send a
@@ -61,11 +62,7 @@ Show a list of virtual machines still running after crashing the lab with
 .BR \-F ", " \-\-keep\-fs
 Preserve changes to the virtual machines by not deleting machines' filesystems
 .RI ( .disk " files)."
-By default,
-.BR vcrash (1)
-is invoked with
-.BR \-\-remove\-fs
-so the filesystems are deleted.
+By default, the filesystems are deleted.
 .TP
 .BR \-k ", " \-\-just\-kill
 Crash machines as usual but skip the attempts with

--- a/core/man/man1/vcrash.1
+++ b/core/man/man1/vcrash.1
@@ -20,6 +20,7 @@ may result in a dirty shutdown where integrity of the virtual machines'
 filesystems
 .RI ( .disk " files)"
 cannot be guaranteed.
+Therefore, by default, filesystems are removed.
 First, the UML management console client,
 .BR uml_mconsole ,
 is used to send a
@@ -53,13 +54,20 @@ to shutdown the first host reported by
 By default, machines owned by the current user are targetted.
 .SS Options affecting how machines are crashed
 .TP
+.BR \-F ", " \-\-keep\-fs
+Preserve changes to the virtual machines by not deleting machines' filesystems
+.RI ( .disk " files)."
+By default,
+.B vcrash
+removes the filesystems.
+.TP
 .BR \-k ", " \-\-just\-kill
 Crash machines as usual but skip the attempts with
 .BR uml_mconsole .
 The method is generally faster but may corrupt the machines' filesystems
 (which is not an issue if
-.B \-\-remove\-fs
-is used since they will get deleted).
+.B \-\-keep\-fs
+is not used since they will get deleted).
 .TP
 .BR \-q ", " \-\-quick
 Disable checking if machines have actually terminated.
@@ -72,11 +80,6 @@ however it also does not send a
 signal (i.e., only
 .B SIGKILL
 is used).
-.TP
-.BR \-r ", " \-\-remove\-fs
-After crashing a machine delete its filesystem
-.RI ( .disk " file),
-if exists.
 .SS Miscellaneous options
 .TP
 .B \-\-help


### PR DESCRIPTION
vcrash now deletes the COW filesystem by default and has a `--keep-fs` option to avoid this behaviour (replacing `--remove-fs`). This is in line with lcrash.

As mentioned in Issue #109, vhalt/lhalt are the opposite and will *keep* the fs by default, and have a `--remove-fs` option to delete it.