### PR TITLE
Disable hub log if HUB_LOG is empty string (fix issue #111)

### DIFF
--- a/core/bin/vcommon
+++ b/core/bin/vcommon
@@ -632,34 +632,38 @@ invoke_uml_switch() {
    
    printed_uml_switch_cmd="${uml_switch_cmd[*]} < /dev/null &"
 
-   # We need to disable buffering on standard output, otherwise the hub log
-   # may miss vital log messages when uml_switch is killed.
-   line_buffered_uml_switch_cmd=(
-      "stdbuf" "--output=0" "--"
-      "${uml_switch_cmd[@]}"
-   )
-
-   # shellcheck disable=SC2016
-   hub_log_cmd=(
-      "stdbuf" "--output=0" "--"
-      "awk"
-         "-v" "HUB=$socket"
-         "-v" "USER=$USER_ID"
-         "-v" "TIME=$(date --iso-8601=seconds)"
-         '{printf "%s %15s %25s %s\n", TIME, USER, HUB, $0}'
-   )
-
    if [ -n "$just_print" ]; then
       echo "Not running ==> $printed_uml_switch_cmd"
-   else
-      [ -n "$verbose" ] && echo "Running ==> $printed_uml_switch_cmd"
+      return
+   fi
+
+   [ -n "$verbose" ] && echo "Running ==> $printed_uml_switch_cmd"
+
+   if [ -n "$HUB_LOG" ]; then
+      # We need to disable buffering on standard output, otherwise the hub log
+      # may miss vital log messages when uml_switch is killed.
+      line_buffered_uml_switch_cmd=(
+         "stdbuf" "--output=0" "--"
+         "${uml_switch_cmd[@]}"
+      )
+
+      # shellcheck disable=SC2016
+      hub_log_cmd=(
+         "stdbuf" "--output=0" "--"
+         "awk"
+            "-v" "HUB=$socket"
+            "-v" "USER=$USER_ID"
+            '{print strftime("%Y-%m-%dT%H:%M:%S%z"), USER, HUB, $0}'
+      )
 
       "${line_buffered_uml_switch_cmd[@]}" < /dev/null 2>&1 |
          "${hub_log_cmd[@]}" >> "$HUB_LOG" &
+   else
+      "${uml_switch_cmd[@]}" < /dev/null > /dev/null 2>&1 &
    fi
 
    # Wait for uml_switch to start
-   [ -z "$just_print" ] && wait_for_socket "$socket"
+   wait_for_socket "$socket"
 }
 
 

--- a/core/man/man5/netkit.conf.5
+++ b/core/man/man5/netkit.conf.5
@@ -108,7 +108,7 @@ except add to the end of the socket filename.
 .B HUB_LOG
 Filepath of the virtual hub log.
 This contains informational or error messages from the virtual hub processes.
-This log cannot be disabled.
+Like the command log, this can be disabled by setting to an empty string.
 .SS Virtual machine default parameters
 Most of these parameters can be overridden by command-line options in
 .BR vstart (1)

--- a/core/netkit.conf.default
+++ b/core/netkit.conf.default
@@ -37,7 +37,8 @@ HUB_SOCKET_DIR="$HOME/.netkit/hubs"
 HUB_SOCKET_PREFIX="vhub"
 HUB_SOCKET_EXTENSION=".cnct"
 
-# Log file to record uml_switch output in
+# Log file to record uml_switch output (use a null file name to disable
+# logging).
 HUB_LOG="$HUB_SOCKET_DIR/vhubs.log"
 
 # Default mount directory used by vpackage


### PR DESCRIPTION
Like `LOGFILENAME`, give the ability to disable the virtual hub log by setting the `HUB_LOG` configuration variable to the empty string. This fixes Issue #111.

This patch also makes the timestamp update for each log message by updating it dynamically with `strftime()` - the original solution set a static timestamp when the command was invoked. The extra padding around fields in the log has also been removed, since it was redundant.