### PR TITLE
Redirect `vdump --verbose` to stderr (fix Issue #110)

### DIFF
--- a/core/bin/vdump
+++ b/core/bin/vdump
@@ -58,7 +58,9 @@ $(usage_line)
 Dump packets from a Netkit DOMAIN (collision domain) to standard output.
 
 $(help_option)
-  -v, --verbose       show the commands being ran
+  -v, --verbose       show the commands being ran. To avoid conflict with the
+                        packet dump output, these messages will get sent to
+                        standard error
 $(version_option)
 
 END_OF_HELP
@@ -150,5 +152,5 @@ fi
 
 uml_dump_cmd=( "uml_dump" "$socket" )
 
-[ -n "$verbose" ] && echo "Running ==> ${uml_dump_cmd[*]}"
+[ -n "$verbose" ] && echo 1>&2 "Running ==> ${uml_dump_cmd[*]}"
 "${uml_dump_cmd[@]}"

--- a/core/man/man1/vdump.1
+++ b/core/man/man1/vdump.1
@@ -33,6 +33,8 @@ Display a usage message and exit.
 .TP
 .BR \-v ", " \-\-verbose
 Show the commands being ran.
+To avoid mixing messages with the packet dump output,
+all verbose output will be redirected to standard error.
 .TP
 .B \-\-version
 Output version information and exit.


### PR DESCRIPTION
`vdump --verbose` messages now go to standard error to avoid mixing up with the packet dump output stream. This patch remediates Issue #110.