### PR TITLE
Show KB unit in vlist memory column

### DIFF
--- a/core/bin/vcommon
+++ b/core/bin/vcommon
@@ -326,7 +326,7 @@ get_vhost_info_by_pid() {
    # Effective user ID of the process (full username if not too long)
    vhost_info[owner]=$(ps --no-headers --format euser --pid "$pid")
 
-   # Total virtual memory usage of the process.
+   # Total virtual memory usage of the process in KiB.
    # Logically this should be the sum of every process in the group (PGID),
    # however in practice just taking the value of the parent process is enough.
    # The value should equate to roughly the size of the machine's memory.

--- a/core/bin/vlist
+++ b/core/bin/vlist
@@ -106,11 +106,10 @@ print_vhost_summary() {
    #   USER    20
    #   VHOST   20
    #   PID      5
-   #   SIZE     9
-   # A single space is added between each column, too (3 between SIZE and
-   # INTERFACES).
-   [ -z "$no_header" ] && echo "USER                 VHOST                  PID      SIZE   INTERFACES"
-
+   #   SIZE    11
+   # A single space is added between each column, too (or 3 if field names are
+   # close).
+   [ -z "$no_header" ] && echo "USER                 VHOST                  PID   SIZE (KB)   INTERFACES"
    # Iterate over the PIDs of running Netkit instances.
    # The process hierarchy (relevance of the PGID) is documented in
    # scripts_utils.
@@ -126,7 +125,7 @@ print_vhost_summary() {
 
       get_vhost_info_by_pid "$pid"
 
-      # Total virtual memory usage of the process.
+      # Total virtual memory usage of the process in KiB.
       # Logically this should be the sum of every process in the group (PGID),
       # however in practice just taking the value of the parent process is
       # enough. The value should equate to roughly the size of the machine's
@@ -134,7 +133,7 @@ print_vhost_summary() {
       ((total_memory_usage += vhost_info[memory_usage]))
 
       # No column will be truncated on a value that is too long
-      printf "%-20s %-20s %5d %9d   " \
+      printf "%-20s %-20s %5d %11d   " \
          "${vhost_info[owner]}" \
          "${vhost_info[umid]}" \
          "${vhost_info[pid]}" \

--- a/core/man/man1/vlist.1
+++ b/core/man/man1/vlist.1
@@ -27,7 +27,8 @@ Killing this will kill the entire machine.
 Username of the process owner.
 .TP
 .B Used mem
-Memory used by all of the virtual machine's processes on the host, in kilobytes.
+Memory used by all of the virtual machine's processes on the host,
+in kilobytes.
 .SS Emulation parameters
 .TP
 .B Kernel


### PR DESCRIPTION
Short patch to make vlist display the memory unit (KB) in its column label, otherwise the unit is ambiguous and has to be inferred from other contexts.