### PR TITLE
Always use conhost.exe with the "wsl" xterm option (+ rename the option to "conhost")

### DIFF
--- a/core/bash-completion/completions/vstart
+++ b/core/bash-completion/completions/vstart
@@ -38,7 +38,7 @@ _vstart() {
 
    local con0_args=( "xterm" "this" "tmux" "pty" "port:" "none" )
    local con1_args=( "xterm" "this" "pty" "port:" "none" )
-   local xterm_args=( "alacritty" "gnome" "kitty" "kitty-tab" "konsole" "wsl" "wt" "xterm" )
+   local xterm_args=( "alacritty" "conhost" "gnome" "kitty" "kitty-tab" "konsole" "wt" "xterm" )
 
    if [ "${#@}" -ge 5 ]; then
       # Passthrough options to vstart are being autocompleted (the parent

--- a/core/bin/block-wrapper
+++ b/core/bin/block-wrapper
@@ -62,11 +62,11 @@ wt_safe_bash_cmd=( "bash" "-c" "$pid_cmd\\; ${kernel_cmd[*]@Q}" )
 
 case $term in
    alacritty)  alacritty --command                                                         "${bash_cmd[@]}";;
+   conhost)    conhost.exe -- wsl.exe --exec                                               "${bash_cmd[@]}" > /dev/null 2>&1;;
    gnome)      gnome-terminal --title "$vhost" --                                          "${bash_cmd[@]}";;
    kitty)      kitty --title "$vhost"                                                      "${bash_cmd[@]}";;
    kitty-tab)  "$NETKIT_HOME/bin/kitty-tab.sh"                                             "${bash_cmd[@]}";;
    konsole)    konsole --nofork --title "$vhost" -e                                        "${bash_cmd[@]}";;
-   wsl)        cmd.exe /c start wsl.exe                                                    "${bash_cmd[@]}";;
    wt)         wt.exe --suppressApplicationTitle --title "$vhost" wsl.exe --exec           "${wt_safe_bash_cmd[@]}";;
    xterm)      xterm -xrm 'XTerm*allowTitleOps: false' -T "$vhost" -e                      "${bash_cmd[@]}";;
    tmux)       tmux -L netkit -f "$NETKIT_HOME/tools/tmux.conf" new-session -d -s "$vhost" "${bash_cmd[@]}";;

--- a/core/bin/vconnect
+++ b/core/bin/vconnect
@@ -91,11 +91,11 @@ open_terminal() {
 
    case $TERM_TYPE in
       alacritty)     term_cmd=( "alacritty" "--command" );;
+      conhost)       term_cmd=( "conhost.exe" "--" "wsl.exe" "--exec" );;
       kitty)         term_cmd=( "kitty" );;
       kitty-tab)     term_cmd=( "$NETKIT_HOME/bin/kitty-tab.sh" );;
       konsole)       term_cmd=( "konsole" "--nofork" "-e" );;
-      wsl)           term_cmd=( "cmd.exe" "/c" "start" "wsl.exe" );;
-      wt)            term_cmd=( "cmd.exe" "/c" "wt.exe" "--profile" "netkit" "wsl.exe" );;
+      wt)            term_cmd=( "wt.exe" "wsl.exe" "--exec" );;
       xterm)         term_cmd=( "xterm" "-e" );;
       *)
          echo "Terminal '$TERM_TYPE' not supported, defaulting to xterm."

--- a/core/bin/vstart
+++ b/core/bin/vstart
@@ -138,14 +138,14 @@ Console settings can be altered by the following options:
       --xterm=TYPE    specify the terminal emulator application. The following
                         values are supported:
                           alacritty    use the lightweight Alacritty terminal
+                          conhost      use Windows Subsystem for Linux (WSL) in
+                                        a conhost.exe window
                           gnome        use the GNOME Terminal
                           kitty        use the lightweight Kitty terminal
                           kitty-tab    same as above, but different virtual
                                         machines are opened in different kitty
                                         tabs of the same window
                           konsole      use the KDE Konsole
-                          wsl          use Windows Subsystem for Linux (WSL) in
-                                        a conhost.exe window
                           wt           use Windows Subsystem for Linux (WSL) in
                                         a Windows Terminal window
                           xterm        use the standard xterm (default)
@@ -494,7 +494,7 @@ while true; do
          TERM_TYPE=$2
          shift
 
-         if [[ ! "$TERM_TYPE" =~ ^(konsole|gnome|xterm|alacritty|kitty|kitty-tab|wsl|wt)$ ]]; then
+         if [[ ! "$TERM_TYPE" =~ ^(alacritty|conhost|gnome|kitty|kitty-tab|konsole|wt|xterm)$ ]]; then
             error "'$TERM_TYPE' is an invalid terminal emulator"
             usage 1
          fi
@@ -553,9 +553,9 @@ if [ "$VM_CON0" = "tmux" ] && [ "$TMUX_OPEN_TERMS" = "yes" ] || [ "$VM_CON0" = "
    # Some xterm option arguments are not their relevant executable's name. We
    # hence map these edge cases here.
    case $TERM_TYPE in
+      conhost)       term_executable="conhost.exe";;
       gnome)         term_executable="gnome-terminal";;
       kitty-tab )    term_executable="kitty";;
-      wsl)           term_executable="wsl.exe";;
       wt)            term_executable="wt.exe";;
       *)             term_executable=$TERM_TYPE;;
    esac

--- a/core/man/man1/vstart.1
+++ b/core/man/man1/vstart.1
@@ -269,6 +269,9 @@ Supported values are:
 .B alacritty
 The lightweight and hardware-accelerated Alacritty terminal.
 .TP
+.B conhost
+Use Windows Subsystem for Linux (WSL) with the Windows Console Host.
+.TP
 .B gnome
 Use the GNOME Terminal, GNOME's default terminal emulator.
 .TP
@@ -282,13 +285,6 @@ but different machiens are opened in different tabs of the same window.
 .TP
 .B konsole
 Use Konsole, KDE's default terminal emulator.
-.TP
-.B wsl
-Use Windows Subsystem for Linux (WSL) with the default Windows terminal
-emulator.
-This is traditionally the Windows Console Host,
-.BR conhost.exe ,
-but modern systems may use Windows Terminal.
 .TP
 .B wt
 Use Windows Subsystem for Linux (WSL) with the Windows Terminal terminal

--- a/core/man/man5/netkit.conf.5
+++ b/core/man/man5/netkit.conf.5
@@ -229,8 +229,8 @@ option:
 .BR \-\-xterm =\fITYPE\fR
 .IP
 Values:
-.BR alacritty ", " gnome ", " kitty ", " kitty\-tab ", " konsole ", " wsl ", "
-.BR wt ", and " xterm .
+.BR alacritty ", " conhost ", " gnome ", " kitty ", " kitty\-tab ", "
+.BR konsole ", " wt ", and " xterm .
 .SS Lab launch parameters
 These options control how a lab is started.
 Some can be overridden by

--- a/core/netkit.conf.default
+++ b/core/netkit.conf.default
@@ -79,8 +79,8 @@ VM_CON1=none
 # console option argument is tmux.
 TMUX_OPEN_TERMS=no
 
-# Terminal emulator for consoles. Allowed values are: alacritty, gnome, kitty,
-# kitty-tab, konsole, wsl, wt, and xterm.
+# Terminal emulator for consoles. Allowed values are: alacritty, conhost,
+# gnome, kitty, kitty-tab, konsole, wt, and xterm.
 TERM_TYPE=xterm
 
 

--- a/core/setup_scripts/change_terminal.sh
+++ b/core/setup_scripts/change_terminal.sh
@@ -53,10 +53,10 @@ Current terminal emulator (TERM_TYPE): '$TERM_TYPE'
 Which terminal emulator would you like to use for Netkit machines?
    (1) xterm - reliable, stable but ancient UI (default installation)
    (2) Alacritty - modern and GPU-accelerated terminal emulator
-   (3) kitty - another modern and GPU-accelerated emulator
-   (4) kitty-tab - start all machines in unique tabs of the same kitty window
-   (5) GNOME Terminal - default terminal for Ubuntu
-   (6) wsl - WSL compatiblity through the Windows Console (conhost.exe)
+   (3) conhost - WSL compatiblity through the Windows Console Host (conhost.exe)
+   (4) kitty - another modern and GPU-accelerated emulator
+   (5) kitty-tab - start all machines in unique tabs of the same kitty window
+   (6) GNOME Terminal - default terminal for Ubuntu
    (7) wt - WSL compatibility via Windows Terminal (recommended for WSL hosts)
 
 The TERM_TYPE variable will be set in:
@@ -94,6 +94,17 @@ while true; do
          break
          ;;
       3)
+         if ! command -v -- "conhost.exe" > /dev/null 2>&1; then
+            echo 1>&2 \
+               "$SCRIPTNAME: conhost.exe: command not found. Is WSL configured to share environment variables with Windows?"
+            exit 1
+         fi
+
+         term_type="conhost"
+         term_name="Windows Console Host"
+         break
+         ;;
+      4)
          if ! command -v -- "kitty" > /dev/null 2>&1; then
             sudo apt-get update
             sudo apt-get install kitty
@@ -103,7 +114,7 @@ while true; do
          term_name="kitty"
          break
          ;;
-      4)
+      5)
          if ! command -v -- "kitty" > /dev/null 2>&1; then
             sudo apt-get update
             sudo apt-get install kitty
@@ -113,7 +124,7 @@ while true; do
          term_name="kitty-tab"
          break
          ;;
-      5)
+      6)
          if ! command -v -- "gnome-terminal" > /dev/null 2>&1; then
             sudo apt-get update
             sudo apt-get install gnome-terminal
@@ -121,17 +132,6 @@ while true; do
 
          term_type="gnome"
          term_name="GNOME Terminal"
-         break
-         ;;
-      6)
-         if ! command -v -- "wsl.exe" > /dev/null 2>&1; then
-            echo 1>&2 \
-               "$SCRIPTNAME: wsl.exe: command not found. Is WSL configured to share environment variables with Windows?"
-            exit 1
-         fi
-
-         term_type="wsl"
-         term_name="Windows Console"
          break
          ;;
       7)

--- a/core/setup_scripts/check_configuration.d/7_check_terminal_emulators.sh
+++ b/core/setup_scripts/check_configuration.d/7_check_terminal_emulators.sh
@@ -29,11 +29,11 @@ echo ">  Checking availability of terminal emulator applications:"
 
 terminal_emulators=(
    "alacritty"
+   "conhost.exe"
    "gnome-terminal"
    "kitty"
    "konsole"
    "tmux"
-   "wsl.exe"
    "wt.exe"
    "xterm"
 )

--- a/tests/configs/35-wsl
+++ b/tests/configs/35-wsl
@@ -1,7 +1,7 @@
 NAME=WSL compatiblity
-DESCRIPTION=Simple lab with two machines joined by a router, using Gnome terminal emulator.
+DESCRIPTION=Simple lab with two machines joined by a router, using Windows Console Host.
 LAB_FOLDER=abr
 LAB_TIMEOUT=60
 FILES=ping_successful_a,ping_successful_b
 TIMEOUT=90
-TERMINAL=wsl
+TERMINAL=conhost


### PR DESCRIPTION
With the advent of Windows 11, Microsoft have now made Windows Terminal the default emulator application on Windows. The user can change the default back to the Windows Console Host (conhost.exe).

Using `--xterm=wsl` with vstart will launch VMs by invoking cmd.exe. This will cause Windows to use the *default* terminal emulator--**not always** (as documented in Netkit-JH) ConHost. This presents the following issue: if the system default is Windows Terminal, Netkit-JH will launch the VM in Windows Terminal with the "wsl" option; this makes `--xterm=wsl` and `--xterm=wt` practically equivalent.

This patch changes the "wsl" option so ConHost is *always* used (by invoking `conhost.exe` directly). Therefore, regardless of the system's default terminal emulator, the user can always choose with `--xterm` between ConHost and Windows Terminal.

The patch also renames the "wsl" option to "conhost", which makes much more sense.