### PR TITLE
Bugfix where lhalt -r couldn't be used *without* -q

### DIFF
--- a/core/bin/lhalt
+++ b/core/bin/lhalt
@@ -166,7 +166,7 @@ if [ ! -d "$lab_dir" ]; then
 fi
 
 # Filesystem cannot be removed if we are working in quick mode
-if [ -n "$rm_fs" ] && [ -z "$quick_mode" ]; then
+if [ -n "$rm_fs" ] && [ -n "$quick_mode" ]; then
    error "filesystems cannot be removed (-r) when working in quick mode (-q)"
    exit 1
 fi


### PR DESCRIPTION
As per the documentation, `-r`/`--remove-fs` cannot be used in conjunction with `-q`/`--quick` for either lhalt or vhalt.

The CLI parsing for lhalt has a bug where it will instead error when `--remove-fs` is **not** used with `--quick`.

This patch just flips one of the test conditions.