### PR TITLE
Disable bird and bird6 services

### DIFF
--- a/fs/disabled-services
+++ b/fs/disabled-services
@@ -1,6 +1,8 @@
 apache2
 avahi-daemon
 bind9
+bird
+bird6
 cron
 dbus
 dnsmasq


### PR DESCRIPTION
Stop the bird and bird6 services from auto-starting on boot.