### PR TITLE
Escape DOT and XML metacharacters in linfo mapping (fixes Issue #73)

### DIFF
--- a/core/bin/linfo
+++ b/core/bin/linfo
@@ -132,6 +132,24 @@ dot_escape() {
 
 
 ###############################################################################
+# Suitably escape a substituted string in XML.
+# Usage:
+#   xml_escape STR
+# Arguments:
+#   $1 - string to escape
+###############################################################################
+xml_escape() {
+   # Replace &><"' with their respective XML escapes.
+   sed \
+      --expression "s/\&/\&amp;/g" \
+      --expression "s/>/\&gt;/g" \
+      --expression "s/</\&lt;/g" \
+      --expression "s/\"/\&quot;/g" \
+      --expression "s/'/\&apos;/g" <<< "$1"
+}
+
+
+###############################################################################
 # Generate a DOT language graph from a list of lab.conf files and virtual
 # machine names and write to standard output.
 # Usage:
@@ -199,7 +217,7 @@ EOF
          # safe.
          interface_ids[$vhost]+=" $opt "
       else
-         opts[$vhost]+="$opt${value+" = $value"}<BR/>"
+         opts[$vhost]+="$(xml_escape "$opt${value+" = $value"}")<BR/>"
       fi
    done < <(grep --extended-regexp --no-filename -- "^$hostname_regex\[.*\]" "${lab_confs[@]}")
 
@@ -208,7 +226,7 @@ EOF
       cat << EOF
    "$(dot_escape "$vhost")" [
       shape="box",
-      label=<$vhost<FONT POINT-SIZE="10"><BR/>${opts[$vhost]}</FONT>>,
+      label=<$(xml_escape "$vhost")<FONT POINT-SIZE="10"><BR/>${opts[$vhost]}</FONT>>,
       height=0.5,
       width=0.5
    ]

--- a/core/bin/linfo
+++ b/core/bin/linfo
@@ -119,6 +119,19 @@ lab_map() {
 
 
 ###############################################################################
+# Suitably escape an identifier in the DOT language.
+# Usage:
+#   dot_escape STR
+# Arguments:
+#   $1 - string to escape
+###############################################################################
+dot_escape() {
+   # Backslash-escape all quotation marks.
+   echo "${1//\"/\\\"}"
+}
+
+
+###############################################################################
 # Generate a DOT language graph from a list of lab.conf files and virtual
 # machine names and write to standard output.
 # Usage:
@@ -174,7 +187,7 @@ EOF
 
          # Add an edge between the machine and its collision domain
          cat << EOF
-   "$vhost" -- "$value" [
+   "$(dot_escape "$vhost")" -- "$(dot_escape "$value")" [
       taillabel=<<TABLE BGCOLOR="white" BORDER="0" CELLPADDING="1" CELLSPACING="0"><TR><TD>eth$opt</TD></TR></TABLE>>,
       labeldistance=1.5,
       labelfontsize=8.0
@@ -193,7 +206,7 @@ EOF
    # Label each machine with its hostname and vstart options
    for vhost in "${lab_vhosts[@]}"; do
       cat << EOF
-   "$vhost" [
+   "$(dot_escape "$vhost")" [
       shape="box",
       label=<$vhost<FONT POINT-SIZE="10"><BR/>${opts[$vhost]}</FONT>>,
       height=0.5,
@@ -205,7 +218,7 @@ EOF
    # Remove bounding box from collision domain labels (just text)
    for hub_name in "${hub_names[@]}"; do
       cat << EOF
-   "$hub_name" [
+   "$(dot_escape "$hub_name")" [
       shape="plaintext",
       width=0,
       height=0,

--- a/core/bin/vcommon
+++ b/core/bin/vcommon
@@ -839,8 +839,7 @@ inet_regex="((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-
 # Regular expression for matching a collision domain name. This choice is
 # arbitrary (though some characters MUST be avoided), but should allow for all
 # reasonable use-cases.
-# NOTE: must not allow commas, forward slashes, or whitespace (for UML CLI
-# parsing). Quotes must also be banned (for linfo mapping). Domains must also
-# be also be shorter than the length of UNIX_PATH_MAX when combined with the
-# other hub socket filepath parts.
+# NOTE: must not allow commas, forward slashes, or whitespace. It must be also
+# be shorter than the length of UNIX_PATH_MAX when combined with the other hub
+# socket filepath parts.
 collision_domain_name_regex="([[:alnum:]_.-]{1,$(get_max_collision_domain_name_len)})"

--- a/core/bin/vcommon
+++ b/core/bin/vcommon
@@ -839,7 +839,8 @@ inet_regex="((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-
 # Regular expression for matching a collision domain name. This choice is
 # arbitrary (though some characters MUST be avoided), but should allow for all
 # reasonable use-cases.
-# NOTE: must not allow commas, forward slashes, or whitespace. It must be also
-# be shorter than the length of UNIX_PATH_MAX when combined with the other hub
-# socket filepath parts.
+# NOTE: must not allow commas, forward slashes, or whitespace (for UML CLI
+# parsing). Quotes must also be banned (for linfo mapping). Domains must also
+# be also be shorter than the length of UNIX_PATH_MAX when combined with the
+# other hub socket filepath parts.
 collision_domain_name_regex="([[:alnum:]_.-]{1,$(get_max_collision_domain_name_len)})"


### PR DESCRIPTION
In the rare cases where machines, collision domains, or options/values have DOT language or XML special characters in them, GraphViz will produce unexpected results when generating a lab map with `linfo --map`. This patch fixes this behaviour by sufficiently escaping the characters. This fixes Issue #73.

Since all substituted identifiers are quoted, the only DOT language metacharacter that must be escaped is the double quote:
`"` -> `\"`

All of the XML substitutions are text content, so just require the usual 5 metacharacters escaped:
`&` -> `&amp;`
`>` -> `&gt;`
`<` -> `&lt;`
`"` -> `&quot;`
`'` -> `&apos;`