### PR TITLE
Install process bugfixes

### DIFF
--- a/core/setup_scripts/check_configuration.d/4_check_manpath.sh
+++ b/core/setup_scripts/check_configuration.d/4_check_manpath.sh
@@ -30,8 +30,8 @@ echo -n ">  Checking for availability of man pages... "
 # MANPATH could alternatively be matched to the Netkit man page directory with
 # a regular expression, however this would be messy with the allowance of
 # trailing and back-to-back forward slashes, and more importantly symbolic
-# links. This means the test depends on the man/ directory having netkit.7.
-if ! [ "$(man --where 7 netkit)" -ef "$NETKIT_HOME/man/man7/netkit.7" ]; then
+# links. This means the test depends on the man/ directory having netkit-jh.7.
+if ! [ "$(man --where 7 netkit-jh)" -ef "$NETKIT_HOME/man/man7/netkit-jh.7" ]; then
    new_manpath="${MANPATH:+"\$MANPATH:"}:$NETKIT_HOME/man/"
 
    cat << END_OF_DIALOG

--- a/install-netkit-jh.sh
+++ b/install-netkit-jh.sh
@@ -337,8 +337,12 @@ fi
 
 # Restore existing configuration file, if exists
 if [ -n "$backup_dir" ]; then
-   echo "Restoring previous configuration ($backup_dir/netkit.conf)"
-   cp -- "$backup_dir/netkit.conf" "$install_dir"
+   netkit_conf="$backup_dir/netkit.conf"
+   echo "Restoring previous configuration ($netkit_conf)"
+
+   if ! cp -- "$netkit_conf" "$install_dir"; then
+      echo 1>&2 "$SCRIPTNAME: $netkit_conf: File does not exist; ignoring"
+   fi
 fi
 
 


### PR DESCRIPTION
Two quick bug fixes in this patch:
1. The install script now ignores if the old Netkit-JH directory does not have a *netkit.conf* file (with a warning).
2. The man page check configuration script will use the netkit-jh(7) manual, not netkit(7).