### PR TITLE
Add man-db as install dependency

### DIFF
--- a/install-netkit-jh.sh
+++ b/install-netkit-jh.sh
@@ -325,6 +325,7 @@ if [ -z "$no_packages" ]; then
       "jq"           # For update checking via the GitHub API
       "lsof"         # To find unused virtual network hubs
       "make"         # Parallel lab start
+      "man-db"       # For viewing Netkit-JH man pages
       "util-linux"   # kill, getopt, mount, etc (should already be installed)
       "xterm"        # Default terminal emulator for Netkit
    )


### PR DESCRIPTION
Debian and some other distros do not have man-db installed by default.