### PR TITLE
Explicitly set startup service CWD to /root

### DIFF
--- a/core/man/man5/lab.conf.5
+++ b/core/man/man5/lab.conf.5
@@ -233,6 +233,9 @@ For more information, see
 Shell scripts can be created to be ran at the end of a machine's boot phase or
 the start of its shutdown phase.
 The scripts are interpreted with Bash and do not need their executable bit set.
+Their working directory is
+.IR /root ,
+however it is good practice to use absolute paths in them where possible.
 See
 .I /etc/netkit/netkit-phase2
 for how exactly this is implemented.

--- a/fs/filesystem-tweaks/usr/lib/systemd/system/netkit-shutdown.service
+++ b/fs/filesystem-tweaks/usr/lib/systemd/system/netkit-shutdown.service
@@ -6,7 +6,8 @@ Before=shutdown.target
 Type=oneshot
 ExecStart=/etc/netkit/netkit-phase1 start
 ExecStartPost=/etc/netkit/netkit-phase2 start
-StandardOutput=journal+console 
+StandardOutput=journal+console
+WorkingDirectory=/root/
 
 [Install]
 WantedBy=shutdown.target

--- a/fs/filesystem-tweaks/usr/lib/systemd/system/netkit-startup-phase1.service
+++ b/fs/filesystem-tweaks/usr/lib/systemd/system/netkit-startup-phase1.service
@@ -6,6 +6,7 @@ After=netkit-mount.service
 Type=oneshot
 ExecStart=/etc/netkit/netkit-phase1 start
 StandardOutput=journal+console
+WorkingDirectory=/root/
 
 [Install]
 WantedBy=multi-user.target

--- a/fs/filesystem-tweaks/usr/lib/systemd/system/netkit-startup-phase2.service
+++ b/fs/filesystem-tweaks/usr/lib/systemd/system/netkit-startup-phase2.service
@@ -7,6 +7,7 @@ Before=getty@tty0.service getty@tty1.service
 Type=oneshot
 ExecStart=/etc/netkit/netkit-phase2 start
 StandardOutput=journal+console
+WorkingDirectory=/root/
 TimeoutSec=300
 
 [Install]


### PR DESCRIPTION
Set the `WorkingDirectory` directive of the Netkit-JH startup and shutdown services to */root*, since some users write scripts assuming it (which is the correct assumption, this is just to make it explicit).