### PR TITLE
Fix Issue #136: Match tmux session names exactly

### DIFF
--- a/core/bin/vcommand
+++ b/core/bin/vcommand
@@ -90,7 +90,7 @@ tmux_command() {
 
    local target="$session:netkit-vhost.0"
 
-   if ! tmux -L netkit has-session -t "$session" > /dev/null 2>&1; then
+   if ! tmux -L netkit has-session -t "=$session" > /dev/null 2>&1; then
       echo 1>&2 "tmux session does not exist for this machine"
       exit 1
    fi
@@ -104,13 +104,13 @@ tmux_command() {
    fi
 
    # Run command prefixed with a NOP of the UUID for output harvesting
-   tmux -L netkit send-keys -t "$target" -- ": $cmd_uuid; $cmd" Enter
+   tmux -L netkit send-keys -t "=$target" -- ": $cmd_uuid; $cmd" Enter
 
    # Wait for output to be generated
    sleep -- "$timeout"
 
    # Get output buffer
-   tmux_buffer=$(tmux -L netkit capture-pane -t "$target" -S - -p)
+   tmux_buffer=$(tmux -L netkit capture-pane -t "=$target" -S - -p)
 
    [ -n "$verbose" ] && printf "Buffer after command:\n%s\n" "$tmux_buffer"
 

--- a/core/bin/vconnect
+++ b/core/bin/vconnect
@@ -102,7 +102,7 @@ open_terminal() {
          term_cmd=( "xterm" "-e" );;
    esac
 
-   nohup "${term_cmd[@]}" tmux -L netkit attach -t "$vhost" > /dev/null 2>&1 &
+   nohup "${term_cmd[@]}" tmux -L netkit attach -t "=$vhost" > /dev/null 2>&1 &
 }
 
 
@@ -115,7 +115,7 @@ open_terminal() {
 ###############################################################################
 tmux_connect() {
    local vhost=$1
-   tmux -L netkit attach -t="$vhost"
+   tmux -L netkit attach -t "=$vhost"
 }
 
 
@@ -222,15 +222,15 @@ if [ -n "$kill" ]; then
    for vhost in "${vhosts[@]}"; do
       unset killed
 
-      if tmux -L netkit has-session -t "$vhost" 2>/dev/null; then
+      if tmux -L netkit has-session -t "=$vhost" 2>/dev/null; then
          echo "Killing tmux session '$vhost'"
-         tmux -L netkit kill-session -t "$vhost"
+         tmux -L netkit kill-session -t "=$vhost"
          killed=1
       fi
 
-      if tmux -L netkit has-session -t "$vhost-dead" 2>/dev/null; then
+      if tmux -L netkit has-session -t "=$vhost-dead" 2>/dev/null; then
          echo "Killing tmux session '$vhost-dead'"
-         tmux -L netkit kill-session -t "$vhost-dead"
+         tmux -L netkit kill-session -t "=$vhost-dead"
          killed=1
       fi
 
@@ -253,7 +253,7 @@ echo -n "Connecting to '$vhost'."
 
 # Test that the tmux session exists retry_count number of times.
 attempts=0
-while ! tmux -L netkit has-session -t="$vhost" 2> /dev/null; do
+while ! tmux -L netkit has-session -t "=$vhost" 2> /dev/null; do
    ((++attempts))
 
    if [ "$attempts" -eq "$retry_count" ]; then

--- a/core/bin/vcrash
+++ b/core/bin/vcrash
@@ -373,14 +373,14 @@ for vhost in "${vhosts[@]}"; do
       # successfully shut down (if the previous commands returned 0).
 
       # Kill tmux sessions
-      if tmux -L netkit has-session -t "$vhost" 2>/dev/null; then
+      if tmux -L netkit has-session -t "=$vhost" 2>/dev/null; then
          echo "Killing tmux session '$vhost'"
-         tmux -L netkit kill-session -t "$vhost"
+         tmux -L netkit kill-session -t "=$vhost"
       fi
 
-      if tmux -L netkit has-session -t "$vhost-dead" 2>/dev/null; then
+      if tmux -L netkit has-session -t "=$vhost-dead" 2>/dev/null; then
          echo "Killing tmux session '$vhost-dead'"
-         tmux -L netkit kill-session -t "$vhost-dead"
+         tmux -L netkit kill-session -t "=$vhost-dead"
       fi
 
       # Remove filesystem (.disk file) by default

--- a/core/bin/vstart
+++ b/core/bin/vstart
@@ -796,7 +796,7 @@ if [ -z "$just_print" ]; then
 
    if [ "$VM_CON0" = "tmux" ]; then
       # Check if tmux session already exists
-      if tmux -L netkit has-session -t "$vhost" > /dev/null 2>&1; then
+      if tmux -L netkit has-session -t "=$vhost" > /dev/null 2>&1; then
          error "tmux session already exists for machine '$vhost'; kill with 'vconnect --kill'"
          exit 1
       fi


### PR DESCRIPTION
Fix for Issue #136, where Netkit would falsely report a tmux session as existing if its session name was a prefix of an existing session name. I.e.:

```bash
tmux -L netkit new-session -s "foobar"

tmux -L netkit has-session -t "foo" # returns true, Netkit fails creating a tmux session for "foo"
```

This PR uses tmux's exact match operator:
```bash
tmux -L netkit new-session -s "foobar"

tmux -L netkit has-session -t "=foo" # returns false, Netkit succeeds creating a tmux session for "foo"

tmux -L netkit has-session -t "=foobar" # returns true, as expected
```

This is documented behaviour of tmux.